### PR TITLE
Feature/create get endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -92,11 +92,10 @@ func handleError(ctx context.Context, w http.ResponseWriter, err error, data log
 			status = http.StatusNotFound
 		case apierrors.ErrResourceState:
 			status = http.StatusConflict
-		case apierrors.ErrUnableToReadMessage:
-			status = http.StatusBadRequest
-		case apierrors.ErrColIDMismatch:
-			status = http.StatusBadRequest
-		case apierrors.ErrUnableToParseJSON:
+		case apierrors.ErrUnableToReadMessage,
+			apierrors.ErrColIDMismatch,
+			apierrors.ErrUnableToParseJSON,
+			apierrors.ErrWrongColID:
 			status = http.StatusBadRequest
 		default:
 			status = http.StatusInternalServerError

--- a/api/api.go
+++ b/api/api.go
@@ -95,7 +95,9 @@ func handleError(ctx context.Context, w http.ResponseWriter, err error, data log
 		case apierrors.ErrUnableToReadMessage,
 			apierrors.ErrColIDMismatch,
 			apierrors.ErrUnableToParseJSON,
-			apierrors.ErrWrongColID:
+			apierrors.ErrWrongColID,
+			apierrors.ErrImageFilenameTooLong,
+			apierrors.ErrImageInvalidState:
 			status = http.StatusBadRequest
 		default:
 			status = http.StatusInternalServerError

--- a/api/api.go
+++ b/api/api.go
@@ -25,7 +25,11 @@ func Setup(ctx context.Context, r *mux.Router, mongoDB MongoServer) *API {
 		mongoDB: mongoDB,
 	}
 
-	r.HandleFunc("/images", api.CreateImageHandler).Methods("POST")
+	r.HandleFunc("/images", api.CreateImageHandler).Methods(http.MethodPost)
+	r.HandleFunc("/images", api.GetImagesHandler).Methods(http.MethodGet)
+	r.HandleFunc("/images/{id}", api.GetImageHandler).Methods(http.MethodGet)
+	r.HandleFunc("/images/{id}", api.UpdateImageHandler).Methods(http.MethodPut)
+	r.HandleFunc("/images/{id}/publish", api.PublishImageHandler).Methods(http.MethodPost)
 	return api
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -94,6 +94,8 @@ func handleError(ctx context.Context, w http.ResponseWriter, err error, data log
 			status = http.StatusConflict
 		case apierrors.ErrUnableToReadMessage:
 			status = http.StatusBadRequest
+		case apierrors.ErrColIDMismatch:
+			status = http.StatusBadRequest
 		case apierrors.ErrUnableToParseJSON:
 			status = http.StatusBadRequest
 		default:

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -28,6 +28,10 @@ func TestSetup(t *testing.T) {
 
 		Convey("When created the following routes should have been added", func() {
 			So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeTrue)
+			So(hasRoute(api.Router, "/images", http.MethodGet), ShouldBeTrue)
+			So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
+			So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeTrue)
+			So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
 		})
 	})
 }

--- a/api/image.go
+++ b/api/image.go
@@ -39,6 +39,10 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 		License:      newImageRequest.License,
 		Type:         newImageRequest.Type,
 	}
+	if err := newImage.Validate(); err != nil {
+		handleError(ctx, w, err, logdata)
+		return
+	}
 	log.Event(ctx, "storing new image", log.INFO, log.Data{"image": newImage})
 
 	if err := api.mongoDB.UpsertImage(newImage.ID, &newImage); err != nil {

--- a/api/image.go
+++ b/api/image.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ONSdigital/dp-image-api/models"
 	"github.com/ONSdigital/log.go/log"
+	"github.com/gorilla/mux"
 )
 
 // CreateImageHandler is a handler that upserts an image into mongoDB
@@ -27,10 +28,49 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 // GetImagesHandler is a handler that gets all images in a collection from MongoDB
-func (api *API) GetImagesHandler(w http.ResponseWriter, req *http.Request) {}
+func (api *API) GetImagesHandler(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	vars := mux.Vars(req)
+	collectionID := vars["collection_id"]
+	logdata := log.Data{"request": "get /images", "collectionID": collectionID}
+
+	items, err := api.mongoDB.GetImages(ctx, collectionID)
+	if err != nil {
+		handleError(ctx, w, err, logdata)
+		return
+	}
+
+	images := models.Images{
+		Items:      items,
+		Count:      len(items),
+		TotalCount: len(items),
+		Limit:      len(items),
+	}
+
+	if err := WriteJSONBody(ctx, images, w, logdata); err != nil {
+		return
+	}
+	log.Event(ctx, "Successfully retrieved images for a collection", log.INFO, logdata)
+}
 
 // GetImageHandler is a handler that gets an image by its id from MongoDB
-func (api *API) GetImageHandler(w http.ResponseWriter, req *http.Request) {}
+func (api *API) GetImageHandler(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	vars := mux.Vars(req)
+	id := vars["id"]
+	logdata := log.Data{"request": "get /images/{id}", "id": id}
+
+	image, err := api.mongoDB.GetImage(id)
+	if err != nil {
+		handleError(ctx, w, err, logdata)
+		return
+	}
+
+	if err := WriteJSONBody(ctx, image, w, logdata); err != nil {
+		return
+	}
+	log.Event(ctx, "Successfully retrieved image", log.INFO, logdata)
+}
 
 // UpdateImageHandler is a handler that updates an existing image in MongoDB
 func (api *API) UpdateImageHandler(w http.ResponseWriter, req *http.Request) {}

--- a/api/image.go
+++ b/api/image.go
@@ -12,6 +12,11 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// NewID returns a new UUID
+var NewID = func() string {
+	return uuid.NewV4().String()
+}
+
 // CreateImageHandler is a handler that upserts an image into mongoDB
 func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -27,7 +32,7 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 
 	// generate new image from request, mapping only allowed fields at creation time (model newImage in swagger spec)
 	newImage := models.Image{
-		ID:           uuid.NewV4().String(),
+		ID:           NewID(),
 		CollectionID: newImageRequest.CollectionID,
 		State:        models.StateCreated.String(),
 		Filename:     newImageRequest.Filename,

--- a/api/image.go
+++ b/api/image.go
@@ -45,7 +45,7 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	log.Event(ctx, "storing new image", log.INFO, log.Data{"image": newImage})
 
-	if err := api.mongoDB.UpsertImage(newImage.ID, &newImage); err != nil {
+	if err := api.mongoDB.UpsertImage(req.Context(), newImage.ID, &newImage); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
@@ -106,13 +106,13 @@ func (api *API) GetImageHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// get image from mongoDB by id
-	image, err := api.mongoDB.GetImage(id)
+	image, err := api.mongoDB.GetImage(req.Context(), id)
 	if err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
 
-	// if image is not published, vaidate that its collectionID matches que header collection-Id
+	// if image is not published, validate that its collectionID matches the collection-Id header
 	if image.State != models.StatePublished.String() && image.CollectionID != hColID {
 		handleError(ctx, w, apierrors.ErrColIDMismatch, logdata)
 		return
@@ -142,6 +142,6 @@ func (api *API) PublishImageHandler(w http.ResponseWriter, req *http.Request) {
 		handlers.CollectionID.Header(): ctx.Value(handlers.CollectionID.Context()),
 		"request-id":                   ctx.Value(dpHTTP.RequestIdKey),
 	}
-	log.Event(ctx, "update image was called, but it is not implemented yet", log.INFO, logdata)
+	log.Event(ctx, "publish image was called, but it is not implemented yet", log.INFO, logdata)
 	http.Error(w, "Not implemented", http.StatusNotImplemented)
 }

--- a/api/image.go
+++ b/api/image.go
@@ -25,3 +25,15 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	log.Event(ctx, "(noop) successfully created image", log.INFO, logdata)
 }
+
+// GetImagesHandler is a handler that gets all images in a collection from MongoDB
+func (api *API) GetImagesHandler(w http.ResponseWriter, req *http.Request) {}
+
+// GetImageHandler is a handler that gets an image by its id from MongoDB
+func (api *API) GetImageHandler(w http.ResponseWriter, req *http.Request) {}
+
+// UpdateImageHandler is a handler that updates an existing image in MongoDB
+func (api *API) UpdateImageHandler(w http.ResponseWriter, req *http.Request) {}
+
+// PublishImageHandler is a handler that triggers the publishing of an image
+func (api *API) PublishImageHandler(w http.ResponseWriter, req *http.Request) {}

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -147,7 +147,7 @@ func TestCreateImageHandler(t *testing.T) {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
 		mongoDbMock := &mock.MongoServerMock{
-			UpsertImageFunc: func(id string, image *models.Image) error { return nil },
+			UpsertImageFunc: func(ctx context.Context, id string, image *models.Image) error { return nil },
 		}
 		imageApi := GetAPIWithMocks(mongoDbMock, cfg)
 
@@ -222,7 +222,7 @@ func TestCreateImageHandler(t *testing.T) {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
 		mongoDbMock := &mock.MongoServerMock{
-			UpsertImageFunc: func(id string, image *models.Image) error { return errMongoDB },
+			UpsertImageFunc: func(ctx context.Context, id string, image *models.Image) error { return errMongoDB },
 		}
 		imageApi := GetAPIWithMocks(mongoDbMock, cfg)
 
@@ -241,7 +241,7 @@ func TestGetImageHandler(t *testing.T) {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
 		mongoDbMock := &mock.MongoServerMock{
-			GetImageFunc: func(id string) (*models.Image, error) {
+			GetImageFunc: func(ctx context.Context, id string) (*models.Image, error) {
 				switch id {
 				case testCreatedImageID:
 					return &createdImage, nil

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -2,21 +2,33 @@ package api_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-image-api/api"
 	"github.com/ONSdigital/dp-image-api/api/mock"
+	"github.com/ONSdigital/dp-image-api/apierrors"
 	"github.com/ONSdigital/dp-image-api/config"
 	"github.com/ONSdigital/dp-image-api/models"
+	"github.com/ONSdigital/dp-net/handlers"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var newImagePayload = `
+const testCreatedImageID = "createdImageID"
+const testPublishedImageID = "publishedImageID"
+const testCollectionID = "1234"
+
+var errMongoDB = errors.New("MongoDB generic error")
+
+var newImagePayload = fmt.Sprintf(`
 {
-	"collection_id": "1234",
+	"collection_id": "%s",
 	"filename": "some-image-name",
 	"license": {
 		"title": "Open Government Licence v3.0",
@@ -24,40 +36,127 @@ var newImagePayload = `
 	},
 	"type": "chart"
 }
-`
+`, testCollectionID)
 
-var expectedImage = models.Image{
-	CollectionID: "1234",
+var fullImagePayload = fmt.Sprintf(`
+{
+	"id": "%s",
+	"collection_id": "%s",
+	"filename": "some-image-name",
+	"license": {
+		"title": "Open Government Licence v3.0",
+		"href": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+	},
+	"type": "chart",
+	"state": "published",
+	"upload": {
+		"path": "images/025a789c-533f-4ecf-a83b-65412b96b2b7/image-name.png"
+	},
+	"download": {
+		"png": {
+			"1920x1080": {
+				"size": 1024,
+				"href": "http://download.ons.gov.uk/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35/image-name.png",
+				"public": "my-public-bucket",
+				"private": "my-private-bucket"
+			}
+		}
+	}
+}
+`, testPublishedImageID, testCollectionID)
+
+var createdImage = models.Image{
+	ID:           testCreatedImageID,
+	CollectionID: testCollectionID,
+	Filename:     "some-image-name",
+	License: &models.License{
+		Title: "Open Government Licence v3.0",
+		Href:  "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+	},
+	Type:  "chart",
+	State: models.StateCreated.String(),
+}
+
+var publishedImage = models.Image{
+	ID:           testPublishedImageID,
+	CollectionID: testCollectionID,
 	Filename:     "some-image-name",
 	License: &models.License{
 		Title: "Open Government Licence v3.0",
 		Href:  "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
 	},
 	Type: "chart",
+	Upload: &models.Upload{
+		Path: "images/025a789c-533f-4ecf-a83b-65412b96b2b7/image-name.png",
+	},
+	Downloads: map[string]map[string]models.Download{
+		"png": {
+			"1920x1080": models.Download{
+				Size:    1024,
+				Href:    "http://download.ons.gov.uk/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35/image-name.png",
+				Public:  "my-public-bucket",
+				Private: "my-private-bucket",
+			},
+		},
+	},
+	State: models.StatePublished.String(),
+}
+
+var images = models.Images{
+	Items:      []models.Image{createdImage, publishedImage},
+	Count:      2,
+	Limit:      2,
+	TotalCount: 2,
+	Offset:     0,
+}
+
+var emptyImages = models.Images{
+	Items:      []models.Image{},
+	Count:      0,
+	Limit:      0,
+	TotalCount: 0,
+	Offset:     0,
 }
 
 func TestCreateImageHandler(t *testing.T) {
 
+	api.NewID = func() string { return testCreatedImageID }
+
 	Convey("Given an image API that can successfully store valid images in mongoDB", t, func() {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
-		mongoDbMock := &mock.MongoServerMock{}
+		mongoDbMock := &mock.MongoServerMock{
+			UpsertImageFunc: func(id string, image *models.Image) error { return nil },
+		}
 		imageApi := GetAPIWithMocks(mongoDbMock, cfg)
-		var b string
-		b = newImagePayload
 
 		Convey("When a valid new image is posted", func() {
-			r := httptest.NewRequest(http.MethodPost, "http://localhost:24700/images", bytes.NewBufferString(b))
+			r := httptest.NewRequest(http.MethodPost, "http://localhost:24700/images", bytes.NewBufferString(newImagePayload))
 			w := httptest.NewRecorder()
 			imageApi.Router.ServeHTTP(w, r)
-			Convey("Then the created image with the new id is returned with status code 201, expected body and requestID header", func() {
+			Convey("Then a newly created image with the new id and provided details is returned with status code 201", func() {
 				So(w.Code, ShouldEqual, http.StatusCreated)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImage := models.Image{}
 				err = json.Unmarshal(payload, &retImage)
 				So(err, ShouldBeNil)
-				So(retImage, ShouldResemble, expectedImage)
+				So(retImage, ShouldResemble, createdImage)
+			})
+		})
+
+		Convey("When a valid new image with extra fields is posted", func() {
+			r := httptest.NewRequest(http.MethodPost, "http://localhost:24700/images", bytes.NewBufferString(fullImagePayload))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			Convey("Then a newly created image with the new id and provided details is returned with status code 201, ignoring any field that is not supposed to be provided at creation time", func() {
+				So(w.Code, ShouldEqual, http.StatusCreated)
+				payload, err := ioutil.ReadAll(w.Body)
+				So(err, ShouldBeNil)
+				retImage := models.Image{}
+				err = json.Unmarshal(payload, &retImage)
+				So(err, ShouldBeNil)
+				So(retImage, ShouldResemble, createdImage)
 			})
 		})
 
@@ -73,6 +172,193 @@ func TestCreateImageHandler(t *testing.T) {
 			w := httptest.NewRecorder()
 			imageApi.Router.ServeHTTP(w, r)
 			So(w.Code, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+
+	Convey("Given an image API with mongoDB that fails to insert images", t, func() {
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		mongoDbMock := &mock.MongoServerMock{
+			UpsertImageFunc: func(id string, image *models.Image) error { return errMongoDB },
+		}
+		imageApi := GetAPIWithMocks(mongoDbMock, cfg)
+
+		Convey("When a new image is posted a 501 InternalServerError status code is returned", func() {
+			r := httptest.NewRequest(http.MethodPost, "http://localhost:24700/images", bytes.NewBufferString(newImagePayload))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+	})
+}
+
+func TestGetImageHandler(t *testing.T) {
+
+	Convey("Given an image API with mongoDB returning 'created' and 'published' images", t, func() {
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		mongoDbMock := &mock.MongoServerMock{
+			GetImageFunc: func(id string) (*models.Image, error) {
+				switch id {
+				case testCreatedImageID:
+					return &createdImage, nil
+				case testPublishedImageID:
+					return &publishedImage, nil
+				default:
+					return nil, apierrors.ErrImageNotFound
+				}
+			},
+		}
+		imageApi := GetAPIWithMocks(mongoDbMock, cfg)
+
+		Convey("When an existing 'created' image is requested with the valid Collection-Id context value", func() {
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:24700/images/%s", testCreatedImageID), nil)
+			r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			Convey("Then the expected image is returned with status code 200", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				payload, err := ioutil.ReadAll(w.Body)
+				So(err, ShouldBeNil)
+				retImage := models.Image{}
+				err = json.Unmarshal(payload, &retImage)
+				So(err, ShouldBeNil)
+				So(retImage, ShouldResemble, createdImage)
+			})
+		})
+
+		Convey("When an existing 'published' image is requested without a Collection-Id context value", func() {
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:24700/images/%s", testPublishedImageID), nil)
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			Convey("Then the published image is returned with status code 200", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				payload, err := ioutil.ReadAll(w.Body)
+				So(err, ShouldBeNil)
+				retImage := models.Image{}
+				err = json.Unmarshal(payload, &retImage)
+				So(err, ShouldBeNil)
+				So(retImage, ShouldResemble, publishedImage)
+			})
+		})
+
+		Convey("Missing a valid Collection-Id when requesting a non-published image results in a BadRequest response", func() {
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:24700/images/%s", testCreatedImageID), nil)
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("Requesting an inexistent image ID results in a NotFound response", func() {
+			r := httptest.NewRequest(http.MethodGet, "http://localhost:24700/images/inexistent", nil)
+			r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusNotFound)
+		})
+	})
+
+}
+
+func TestGetImagesHandler(t *testing.T) {
+
+	Convey("Given an image API with mongoDB returning the images for the testing Collection-Id", t, func() {
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		mongoDbMock := &mock.MongoServerMock{
+			GetImagesFunc: func(ctx context.Context, collectionID string) ([]models.Image, error) {
+				if collectionID == testCollectionID {
+					return []models.Image{createdImage, publishedImage}, nil
+				}
+				return []models.Image{}, nil
+			},
+		}
+		imageApi := GetAPIWithMocks(mongoDbMock, cfg)
+
+		Convey("When existing images are requested with a valid Collection-Id context and query value", func() {
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:24700/images?collection_id=%s", testCollectionID), nil)
+			r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			Convey("Then the expected images are returned with status code 200", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				payload, err := ioutil.ReadAll(w.Body)
+				So(err, ShouldBeNil)
+				retImages := models.Images{}
+				err = json.Unmarshal(payload, &retImages)
+				So(err, ShouldBeNil)
+				So(retImages, ShouldResemble, images)
+			})
+		})
+
+		Convey("When inexistent images are requested with a valid Collection-Id context and query value", func() {
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:24700/images?collection_id=%s", "otherCollectionId"), nil)
+			r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), "otherCollectionId"))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			Convey("Then an empty list of images is returned with status code 200", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				payload, err := ioutil.ReadAll(w.Body)
+				So(err, ShouldBeNil)
+				retImages := models.Images{}
+				err = json.Unmarshal(payload, &retImages)
+				So(err, ShouldBeNil)
+				So(retImages, ShouldResemble, emptyImages)
+			})
+		})
+
+		Convey("Missing a valid Collection-Id header when requesting images results in a BadRequest response", func() {
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:24700/images?collection_id=%s", testCollectionID), nil)
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("Missing a valid Collection-Id query parmeter when requesting images results in a BadRequest response", func() {
+			r := httptest.NewRequest(http.MethodGet, "http://localhost:24700/images", nil)
+			r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("Providing different values for Collection-Id header and query parameter when requesting images results in a BadRequest response", func() {
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:24700/images?collection_id=%s", testCollectionID), nil)
+			r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), "otherCollectionId"))
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusBadRequest)
+		})
+
+	})
+}
+
+func TestUpdateImageHandler(t *testing.T) {
+	Convey("Given an image API with empty mongoDB", t, func() {
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		imageApi := GetAPIWithMocks(&mock.MongoServerMock{}, cfg)
+
+		Convey("Calling update image results in 501 NotImplemented", func() {
+			r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:24700/images/%s", testCreatedImageID), nil)
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusNotImplemented)
+		})
+	})
+}
+
+func TestPublishImageHandler(t *testing.T) {
+	Convey("Given an image API with empty mongoDB", t, func() {
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+		imageApi := GetAPIWithMocks(&mock.MongoServerMock{}, cfg)
+
+		Convey("Calling publish image results in 501 NotImplemented", func() {
+			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:24700/images/%s/publish", testCreatedImageID), nil)
+			w := httptest.NewRecorder()
+			imageApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusNotImplemented)
 		})
 	})
 }

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/ONSdigital/dp-image-api/models"
 )
 
 //go:generate moq -out mock/mongo.go -pkg mock . MongoServer
@@ -12,4 +13,8 @@ import (
 type MongoServer interface {
 	Close(ctx context.Context) error
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
+	GetImages(ctx context.Context, collectionID string) ([]models.Image, error)
+	GetImage(id string) (*models.Image, error)
+	UpdateImage(ctx context.Context, id string, image *models.Image) error
+	UpsertImage(id string, image *models.Image) (err error)
 }

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -14,7 +14,7 @@ type MongoServer interface {
 	Close(ctx context.Context) error
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	GetImages(ctx context.Context, collectionID string) ([]models.Image, error)
-	GetImage(id string) (*models.Image, error)
+	GetImage(ctx context.Context, id string) (*models.Image, error)
 	UpdateImage(ctx context.Context, id string, image *models.Image) error
-	UpsertImage(id string, image *models.Image) (err error)
+	UpsertImage(ctx context.Context, id string, image *models.Image) (err error)
 }

--- a/api/mock/mongo.go
+++ b/api/mock/mongo.go
@@ -7,12 +7,17 @@ import (
 	"context"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-image-api/api"
+	"github.com/ONSdigital/dp-image-api/models"
 	"sync"
 )
 
 var (
-	lockMongoServerMockChecker sync.RWMutex
-	lockMongoServerMockClose   sync.RWMutex
+	lockMongoServerMockChecker     sync.RWMutex
+	lockMongoServerMockClose       sync.RWMutex
+	lockMongoServerMockGetImage    sync.RWMutex
+	lockMongoServerMockGetImages   sync.RWMutex
+	lockMongoServerMockUpdateImage sync.RWMutex
+	lockMongoServerMockUpsertImage sync.RWMutex
 )
 
 // Ensure, that MongoServerMock does implement api.MongoServer.
@@ -31,6 +36,18 @@ var _ api.MongoServer = &MongoServerMock{}
 //             CloseFunc: func(ctx context.Context) error {
 // 	               panic("mock out the Close method")
 //             },
+//             GetImageFunc: func(id string) (*models.Image, error) {
+// 	               panic("mock out the GetImage method")
+//             },
+//             GetImagesFunc: func(ctx context.Context, collectionID string) ([]models.Image, error) {
+// 	               panic("mock out the GetImages method")
+//             },
+//             UpdateImageFunc: func(ctx context.Context, id string, image *models.Image) error {
+// 	               panic("mock out the UpdateImage method")
+//             },
+//             UpsertImageFunc: func(id string, image *models.Image) error {
+// 	               panic("mock out the UpsertImage method")
+//             },
 //         }
 //
 //         // use mockedMongoServer in code that requires api.MongoServer
@@ -43,6 +60,18 @@ type MongoServerMock struct {
 
 	// CloseFunc mocks the Close method.
 	CloseFunc func(ctx context.Context) error
+
+	// GetImageFunc mocks the GetImage method.
+	GetImageFunc func(id string) (*models.Image, error)
+
+	// GetImagesFunc mocks the GetImages method.
+	GetImagesFunc func(ctx context.Context, collectionID string) ([]models.Image, error)
+
+	// UpdateImageFunc mocks the UpdateImage method.
+	UpdateImageFunc func(ctx context.Context, id string, image *models.Image) error
+
+	// UpsertImageFunc mocks the UpsertImage method.
+	UpsertImageFunc func(id string, image *models.Image) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -57,6 +86,34 @@ type MongoServerMock struct {
 		Close []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+		}
+		// GetImage holds details about calls to the GetImage method.
+		GetImage []struct {
+			// ID is the id argument value.
+			ID string
+		}
+		// GetImages holds details about calls to the GetImages method.
+		GetImages []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// CollectionID is the collectionID argument value.
+			CollectionID string
+		}
+		// UpdateImage holds details about calls to the UpdateImage method.
+		UpdateImage []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+			// Image is the image argument value.
+			Image *models.Image
+		}
+		// UpsertImage holds details about calls to the UpsertImage method.
+		UpsertImage []struct {
+			// ID is the id argument value.
+			ID string
+			// Image is the image argument value.
+			Image *models.Image
 		}
 	}
 }
@@ -124,5 +181,145 @@ func (mock *MongoServerMock) CloseCalls() []struct {
 	lockMongoServerMockClose.RLock()
 	calls = mock.calls.Close
 	lockMongoServerMockClose.RUnlock()
+	return calls
+}
+
+// GetImage calls GetImageFunc.
+func (mock *MongoServerMock) GetImage(id string) (*models.Image, error) {
+	if mock.GetImageFunc == nil {
+		panic("MongoServerMock.GetImageFunc: method is nil but MongoServer.GetImage was just called")
+	}
+	callInfo := struct {
+		ID string
+	}{
+		ID: id,
+	}
+	lockMongoServerMockGetImage.Lock()
+	mock.calls.GetImage = append(mock.calls.GetImage, callInfo)
+	lockMongoServerMockGetImage.Unlock()
+	return mock.GetImageFunc(id)
+}
+
+// GetImageCalls gets all the calls that were made to GetImage.
+// Check the length with:
+//     len(mockedMongoServer.GetImageCalls())
+func (mock *MongoServerMock) GetImageCalls() []struct {
+	ID string
+} {
+	var calls []struct {
+		ID string
+	}
+	lockMongoServerMockGetImage.RLock()
+	calls = mock.calls.GetImage
+	lockMongoServerMockGetImage.RUnlock()
+	return calls
+}
+
+// GetImages calls GetImagesFunc.
+func (mock *MongoServerMock) GetImages(ctx context.Context, collectionID string) ([]models.Image, error) {
+	if mock.GetImagesFunc == nil {
+		panic("MongoServerMock.GetImagesFunc: method is nil but MongoServer.GetImages was just called")
+	}
+	callInfo := struct {
+		Ctx          context.Context
+		CollectionID string
+	}{
+		Ctx:          ctx,
+		CollectionID: collectionID,
+	}
+	lockMongoServerMockGetImages.Lock()
+	mock.calls.GetImages = append(mock.calls.GetImages, callInfo)
+	lockMongoServerMockGetImages.Unlock()
+	return mock.GetImagesFunc(ctx, collectionID)
+}
+
+// GetImagesCalls gets all the calls that were made to GetImages.
+// Check the length with:
+//     len(mockedMongoServer.GetImagesCalls())
+func (mock *MongoServerMock) GetImagesCalls() []struct {
+	Ctx          context.Context
+	CollectionID string
+} {
+	var calls []struct {
+		Ctx          context.Context
+		CollectionID string
+	}
+	lockMongoServerMockGetImages.RLock()
+	calls = mock.calls.GetImages
+	lockMongoServerMockGetImages.RUnlock()
+	return calls
+}
+
+// UpdateImage calls UpdateImageFunc.
+func (mock *MongoServerMock) UpdateImage(ctx context.Context, id string, image *models.Image) error {
+	if mock.UpdateImageFunc == nil {
+		panic("MongoServerMock.UpdateImageFunc: method is nil but MongoServer.UpdateImage was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		ID    string
+		Image *models.Image
+	}{
+		Ctx:   ctx,
+		ID:    id,
+		Image: image,
+	}
+	lockMongoServerMockUpdateImage.Lock()
+	mock.calls.UpdateImage = append(mock.calls.UpdateImage, callInfo)
+	lockMongoServerMockUpdateImage.Unlock()
+	return mock.UpdateImageFunc(ctx, id, image)
+}
+
+// UpdateImageCalls gets all the calls that were made to UpdateImage.
+// Check the length with:
+//     len(mockedMongoServer.UpdateImageCalls())
+func (mock *MongoServerMock) UpdateImageCalls() []struct {
+	Ctx   context.Context
+	ID    string
+	Image *models.Image
+} {
+	var calls []struct {
+		Ctx   context.Context
+		ID    string
+		Image *models.Image
+	}
+	lockMongoServerMockUpdateImage.RLock()
+	calls = mock.calls.UpdateImage
+	lockMongoServerMockUpdateImage.RUnlock()
+	return calls
+}
+
+// UpsertImage calls UpsertImageFunc.
+func (mock *MongoServerMock) UpsertImage(id string, image *models.Image) error {
+	if mock.UpsertImageFunc == nil {
+		panic("MongoServerMock.UpsertImageFunc: method is nil but MongoServer.UpsertImage was just called")
+	}
+	callInfo := struct {
+		ID    string
+		Image *models.Image
+	}{
+		ID:    id,
+		Image: image,
+	}
+	lockMongoServerMockUpsertImage.Lock()
+	mock.calls.UpsertImage = append(mock.calls.UpsertImage, callInfo)
+	lockMongoServerMockUpsertImage.Unlock()
+	return mock.UpsertImageFunc(id, image)
+}
+
+// UpsertImageCalls gets all the calls that were made to UpsertImage.
+// Check the length with:
+//     len(mockedMongoServer.UpsertImageCalls())
+func (mock *MongoServerMock) UpsertImageCalls() []struct {
+	ID    string
+	Image *models.Image
+} {
+	var calls []struct {
+		ID    string
+		Image *models.Image
+	}
+	lockMongoServerMockUpsertImage.RLock()
+	calls = mock.calls.UpsertImage
+	lockMongoServerMockUpsertImage.RUnlock()
 	return calls
 }

--- a/api/mock/mongo.go
+++ b/api/mock/mongo.go
@@ -36,7 +36,7 @@ var _ api.MongoServer = &MongoServerMock{}
 //             CloseFunc: func(ctx context.Context) error {
 // 	               panic("mock out the Close method")
 //             },
-//             GetImageFunc: func(id string) (*models.Image, error) {
+//             GetImageFunc: func(ctx context.Context, id string) (*models.Image, error) {
 // 	               panic("mock out the GetImage method")
 //             },
 //             GetImagesFunc: func(ctx context.Context, collectionID string) ([]models.Image, error) {
@@ -45,7 +45,7 @@ var _ api.MongoServer = &MongoServerMock{}
 //             UpdateImageFunc: func(ctx context.Context, id string, image *models.Image) error {
 // 	               panic("mock out the UpdateImage method")
 //             },
-//             UpsertImageFunc: func(id string, image *models.Image) error {
+//             UpsertImageFunc: func(ctx context.Context, id string, image *models.Image) error {
 // 	               panic("mock out the UpsertImage method")
 //             },
 //         }
@@ -62,7 +62,7 @@ type MongoServerMock struct {
 	CloseFunc func(ctx context.Context) error
 
 	// GetImageFunc mocks the GetImage method.
-	GetImageFunc func(id string) (*models.Image, error)
+	GetImageFunc func(ctx context.Context, id string) (*models.Image, error)
 
 	// GetImagesFunc mocks the GetImages method.
 	GetImagesFunc func(ctx context.Context, collectionID string) ([]models.Image, error)
@@ -71,7 +71,7 @@ type MongoServerMock struct {
 	UpdateImageFunc func(ctx context.Context, id string, image *models.Image) error
 
 	// UpsertImageFunc mocks the UpsertImage method.
-	UpsertImageFunc func(id string, image *models.Image) error
+	UpsertImageFunc func(ctx context.Context, id string, image *models.Image) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -89,6 +89,8 @@ type MongoServerMock struct {
 		}
 		// GetImage holds details about calls to the GetImage method.
 		GetImage []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// ID is the id argument value.
 			ID string
 		}
@@ -110,6 +112,8 @@ type MongoServerMock struct {
 		}
 		// UpsertImage holds details about calls to the UpsertImage method.
 		UpsertImage []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// ID is the id argument value.
 			ID string
 			// Image is the image argument value.
@@ -185,29 +189,33 @@ func (mock *MongoServerMock) CloseCalls() []struct {
 }
 
 // GetImage calls GetImageFunc.
-func (mock *MongoServerMock) GetImage(id string) (*models.Image, error) {
+func (mock *MongoServerMock) GetImage(ctx context.Context, id string) (*models.Image, error) {
 	if mock.GetImageFunc == nil {
 		panic("MongoServerMock.GetImageFunc: method is nil but MongoServer.GetImage was just called")
 	}
 	callInfo := struct {
-		ID string
+		Ctx context.Context
+		ID  string
 	}{
-		ID: id,
+		Ctx: ctx,
+		ID:  id,
 	}
 	lockMongoServerMockGetImage.Lock()
 	mock.calls.GetImage = append(mock.calls.GetImage, callInfo)
 	lockMongoServerMockGetImage.Unlock()
-	return mock.GetImageFunc(id)
+	return mock.GetImageFunc(ctx, id)
 }
 
 // GetImageCalls gets all the calls that were made to GetImage.
 // Check the length with:
 //     len(mockedMongoServer.GetImageCalls())
 func (mock *MongoServerMock) GetImageCalls() []struct {
-	ID string
+	Ctx context.Context
+	ID  string
 } {
 	var calls []struct {
-		ID string
+		Ctx context.Context
+		ID  string
 	}
 	lockMongoServerMockGetImage.RLock()
 	calls = mock.calls.GetImage
@@ -290,31 +298,35 @@ func (mock *MongoServerMock) UpdateImageCalls() []struct {
 }
 
 // UpsertImage calls UpsertImageFunc.
-func (mock *MongoServerMock) UpsertImage(id string, image *models.Image) error {
+func (mock *MongoServerMock) UpsertImage(ctx context.Context, id string, image *models.Image) error {
 	if mock.UpsertImageFunc == nil {
 		panic("MongoServerMock.UpsertImageFunc: method is nil but MongoServer.UpsertImage was just called")
 	}
 	callInfo := struct {
+		Ctx   context.Context
 		ID    string
 		Image *models.Image
 	}{
+		Ctx:   ctx,
 		ID:    id,
 		Image: image,
 	}
 	lockMongoServerMockUpsertImage.Lock()
 	mock.calls.UpsertImage = append(mock.calls.UpsertImage, callInfo)
 	lockMongoServerMockUpsertImage.Unlock()
-	return mock.UpsertImageFunc(id, image)
+	return mock.UpsertImageFunc(ctx, id, image)
 }
 
 // UpsertImageCalls gets all the calls that were made to UpsertImage.
 // Check the length with:
 //     len(mockedMongoServer.UpsertImageCalls())
 func (mock *MongoServerMock) UpsertImageCalls() []struct {
+	Ctx   context.Context
 	ID    string
 	Image *models.Image
 } {
 	var calls []struct {
+		Ctx   context.Context
 		ID    string
 		Image *models.Image
 	}

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -11,5 +11,6 @@ var (
 	ErrResourceState       = errors.New("incorrect resource state")
 	ErrUnableToReadMessage = errors.New("failed to read message body")
 	ErrColIDMismatch       = errors.New("'Collection-Id' header does not match 'collection_id' query parameter")
+	ErrWrongColID          = errors.New("'Collection-Id' header does not match image's 'collection_id'")
 	ErrUnableToParseJSON   = errors.New("failed to parse json body")
 )

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -10,5 +10,6 @@ var (
 	ErrInternalServer      = errors.New("internal error")
 	ErrResourceState       = errors.New("incorrect resource state")
 	ErrUnableToReadMessage = errors.New("failed to read message body")
+	ErrColIDMismatch       = errors.New("'Collection-Id' header does not match 'collection_id' query parameter")
 	ErrUnableToParseJSON   = errors.New("failed to parse json body")
 )

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -13,6 +13,6 @@ var (
 	ErrColIDMismatch        = errors.New("'Collection-Id' header does not match 'collection_id' query parameter")
 	ErrWrongColID           = errors.New("'Collection-Id' header does not match image's 'collection_id'")
 	ErrUnableToParseJSON    = errors.New("failed to parse json body")
-	ErrImageFilenameTooLong = errors.New("Image filename is too long")
-	ErrImageInvalidState    = errors.New("Image state is not a valid state name")
+	ErrImageFilenameTooLong = errors.New("image filename is too long")
+	ErrImageInvalidState    = errors.New("image state is not a valid state name")
 )

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -6,11 +6,13 @@ import (
 
 // A list of error messages for Image API
 var (
-	ErrImageNotFound       = errors.New("image not found")
-	ErrInternalServer      = errors.New("internal error")
-	ErrResourceState       = errors.New("incorrect resource state")
-	ErrUnableToReadMessage = errors.New("failed to read message body")
-	ErrColIDMismatch       = errors.New("'Collection-Id' header does not match 'collection_id' query parameter")
-	ErrWrongColID          = errors.New("'Collection-Id' header does not match image's 'collection_id'")
-	ErrUnableToParseJSON   = errors.New("failed to parse json body")
+	ErrImageNotFound        = errors.New("image not found")
+	ErrInternalServer       = errors.New("internal error")
+	ErrResourceState        = errors.New("incorrect resource state")
+	ErrUnableToReadMessage  = errors.New("failed to read message body")
+	ErrColIDMismatch        = errors.New("'Collection-Id' header does not match 'collection_id' query parameter")
+	ErrWrongColID           = errors.New("'Collection-Id' header does not match image's 'collection_id'")
+	ErrUnableToParseJSON    = errors.New("failed to parse json body")
+	ErrImageFilenameTooLong = errors.New("Image filename is too long")
+	ErrImageInvalidState    = errors.New("Image state is not a valid state name")
 )

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/satori/go.uuid v1.2.0
 	github.com/smartystreets/goconvey v1.6.4
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-mongodb v1.2.0
-	github.com/ONSdigital/dp-net v1.0.3-0.20200519140208-ed50d1f9aa9a
+	github.com/ONSdigital/dp-net v1.0.4-0.20200521155446-34cf3d4fece1
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-healthcheck v1.0.4 h1:mR7y0zEULrq5oOYlrkJ3X8Z2nYdvu2TzQ
 github.com/ONSdigital/dp-healthcheck v1.0.4/go.mod h1:9485FaCfhADi/jtudXVeaoBHMG/MoTTAibpFwovmSec=
 github.com/ONSdigital/dp-mongodb v1.2.0 h1:WFE4p2cJPgTLMICuvU9y4n+3hcbP4WSDeOGz0rwe0lQ=
 github.com/ONSdigital/dp-mongodb v1.2.0/go.mod h1:Yq2GazmrVEn1GEZ0Qw/Igmeo3mzsmKAJst1s7EbSkOo=
-github.com/ONSdigital/dp-net v1.0.3-0.20200519140208-ed50d1f9aa9a h1:WcgkhUjommlsQJr1GoGtzoJGHplAWvwf1s7rD+0a6tg=
-github.com/ONSdigital/dp-net v1.0.3-0.20200519140208-ed50d1f9aa9a/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
+github.com/ONSdigital/dp-net v1.0.4-0.20200521155446-34cf3d4fece1 h1:QR2j7KNU6DOfQj9F4wVQ8DOIrDNuyuEt6kJ2YTm5nSM=
+github.com/ONSdigital/dp-net v1.0.4-0.20200521155446-34cf3d4fece1/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/models/image.go
+++ b/models/image.go
@@ -1,5 +1,14 @@
 package models
 
+// Images represents an array of images model as it is stored in mongoDB and json representation for API
+type Images struct {
+	Count      int     `bson:"count,omitempty"        json:"count"`
+	Offset     int     `bson:"offset_index,omitempty" json:"offset_index"`
+	Limit      int     `bson:"limit,omitempty"        json:"limit"`
+	Items      []Image `bson:"items,omitempty"        json:"items"`
+	TotalCount int     `bson:"total_count,omitempty"  json:"total_count"`
+}
+
 // Image represents an image metadata model as it is stored in mongoDB and json representation for API
 type Image struct {
 	ID           string                         `bson:"_id,omitempty"           json:"id,omitempty"`

--- a/models/image.go
+++ b/models/image.go
@@ -1,5 +1,12 @@
 package models
 
+import (
+	"github.com/ONSdigital/dp-image-api/apierrors"
+)
+
+// MaxFilenameLen is the maximum number of characters allowed for Image filenames
+const MaxFilenameLen = 40
+
 // Images represents an array of images model as it is stored in mongoDB and json representation for API
 type Images struct {
 	Count      int     `bson:"count,omitempty"        json:"count"`
@@ -38,4 +45,19 @@ type Download struct {
 	Href    string `bson:"href,omitempty"           json:"href,omitempty"`
 	Public  string `bson:"public,omitempty"         json:"pubic,omitempty"`
 	Private string `bson:"private,omitempty"        json:"private,omitempty"`
+}
+
+// Validate checks that an image struct complies with the filename and state constraints
+func (i *Image) Validate() error {
+
+	if len(i.Filename) > MaxFilenameLen {
+		return apierrors.ErrImageFilenameTooLong
+	}
+
+	for _, validState := range stateValues {
+		if i.State == validState {
+			return nil
+		}
+	}
+	return apierrors.ErrImageInvalidState
 }

--- a/models/state.go
+++ b/models/state.go
@@ -31,21 +31,21 @@ func (s State) TransitionAllowed(target State) bool {
 		}
 	case StateUploaded:
 		switch target {
-		case StatePublishing, StateDeleted:
+		case StateUploaded, StatePublishing, StateDeleted:
 			return true
 		default:
 			return false
 		}
 	case StatePublishing:
 		switch target {
-		case StatePublished, StateUploaded, StateDeleted:
+		case StatePublishing, StatePublished, StateUploaded, StateDeleted:
 			return true
 		default:
 			return false
 		}
 	case StatePublished:
 		switch target {
-		case StateDeleted:
+		case StatePublished, StateDeleted:
 			return true
 		default:
 			return false

--- a/models/state.go
+++ b/models/state.go
@@ -1,0 +1,56 @@
+package models
+
+// State - iota enum of possible image states
+type State int
+
+// Possible values for a State of an image. It can only be one of the following:
+const (
+	StateCreated State = iota
+	StateUploaded
+	StatePublishing
+	StatePublished
+	StateDeleted
+)
+
+var stateValues = []string{"created", "uploaded", "publishing", "published", "deleted"}
+
+// String returns the string representation of a state
+func (s State) String() string {
+	return stateValues[s]
+}
+
+// TransitionAllowed returns true only if the transition from the current state and the provided targetState is allowed
+func (s State) TransitionAllowed(target State) bool {
+	switch s {
+	case StateCreated:
+		switch target {
+		case StateCreated, StateUploaded, StateDeleted:
+			return true
+		default:
+			return false
+		}
+	case StateUploaded:
+		switch target {
+		case StatePublishing, StateDeleted:
+			return true
+		default:
+			return false
+		}
+	case StatePublishing:
+		switch target {
+		case StatePublished, StateUploaded, StateDeleted:
+			return true
+		default:
+			return false
+		}
+	case StatePublished:
+		switch target {
+		case StateDeleted:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -36,7 +36,7 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 
 	// Get HTTP Server with collectionID checkHeader middleware
 	r := mux.NewRouter()
-	middleware := alice.New(handlers.CheckHeaderMiddleware(handlers.CollectionIDHeaderKey))
+	middleware := alice.New(handlers.CheckHeader(handlers.CollectionID))
 	s := serviceList.GetHTTPServer(cfg.BindAddr, middleware.Then(r))
 
 	// Get MongoDB client

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -54,8 +55,12 @@ func TestRun(t *testing.T) {
 			StartFunc:    func(ctx context.Context) {},
 		}
 
+		serverWg := &sync.WaitGroup{}
 		serverMock := &serviceMock.HTTPServerMock{
-			ListenAndServeFunc: func() error { return nil },
+			ListenAndServeFunc: func() error {
+				serverWg.Done()
+				return nil
+			},
 		}
 
 		funcDoGetMongoDbOk := func(ctx context.Context, cfg *config.Config) (api.MongoServer, error) {
@@ -112,6 +117,7 @@ func TestRun(t *testing.T) {
 			}
 			svcErrors := make(chan error, 1)
 			svcList := service.NewServiceList(initMock)
+			serverWg.Add(1)
 			_, err := service.Run(ctx, svcList, testBuildTime, testGitCommit, testVersion, svcErrors)
 
 			Convey("Then service Run succeeds and all the flags are set", func() {
@@ -126,6 +132,7 @@ func TestRun(t *testing.T) {
 				So(len(initMock.DoGetHTTPServerCalls()), ShouldEqual, 1)
 				So(initMock.DoGetHTTPServerCalls()[0].BindAddr, ShouldEqual, ":24700")
 				So(len(hcMock.StartCalls()), ShouldEqual, 1)
+				serverWg.Wait() // Wait for HTTP server go-routine to finish
 				So(len(serverMock.ListenAndServeCalls()), ShouldEqual, 1)
 			})
 		})


### PR DESCRIPTION
### What

- Added all routes and handlers for image API
- Implemented `GET /images` and `GET /images/{id}`
- Post now stores new images in MongoDB (before this PR it was a no-op)
- `PUT /images/{id}` and `POST /images/{id}/publish` return 501 Not implemented
- Use latest dp-net, which fixes the collectionID middleware issue.
- Image validation at creation time.

### How to review

- Make sure code changes make sense
- Unit tests should pass
- You can try the endpoints, keeping in mind that now it uses the MongoDB backend

### Who can review

Anyone