### PR TITLE
PUT images/id now performs an update with the provided fields only

### DIFF
--- a/models/image.go
+++ b/models/image.go
@@ -41,25 +41,25 @@ type Upload struct {
 
 // Download represents a download variant model
 type Download struct {
-	Size    int    `bson:"size,omitempty"           json:"size,omitempty"`
+	Size    *int   `bson:"size,omitempty"           json:"size,omitempty"`
 	Href    string `bson:"href,omitempty"           json:"href,omitempty"`
 	Public  string `bson:"public,omitempty"         json:"public,omitempty"`
 	Private string `bson:"private,omitempty"        json:"private,omitempty"`
 }
 
-// Validate checks that an image struct complies with the filename and state constraints
+// Validate checks that an image struct complies with the filename and state constraints, if provided.
 func (i *Image) Validate() error {
 
-	if len(i.Filename) > MaxFilenameLen {
-		return apierrors.ErrImageFilenameTooLong
+	if i.Filename != "" {
+		if len(i.Filename) > MaxFilenameLen {
+			return apierrors.ErrImageFilenameTooLong
+		}
 	}
 
-	if i.CollectionID == "" {
-		return apierrors.ErrImageNoCollectionID
-	}
-
-	if _, err := ParseState(i.State); err != nil {
-		return apierrors.ErrImageInvalidState
+	if i.State != "" {
+		if _, err := ParseState(i.State); err != nil {
+			return apierrors.ErrImageInvalidState
+		}
 	}
 
 	return nil
@@ -69,7 +69,7 @@ func (i *Image) Validate() error {
 func (i *Image) StateTransitionAllowed(target string) bool {
 	currentState, err := ParseState(i.State)
 	if err != nil {
-		return false
+		currentState = StateCreated // default value, if state is not present or invalid value
 	}
 	targetState, err := ParseState(target)
 	if err != nil {

--- a/models/image_test.go
+++ b/models/image_test.go
@@ -1,0 +1,88 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-image-api/apierrors"
+	"github.com/ONSdigital/dp-image-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestImageValidation(t *testing.T) {
+
+	Convey("Given an empty image, it is successfully validated", t, func() {
+		image := models.Image{}
+		err := image.Validate()
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Given an image with a filename that is longer than the maximum allowed, it fails to validate with the expected error", t, func() {
+		image := models.Image{
+			Filename: "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch",
+		}
+		err := image.Validate()
+		So(err, ShouldResemble, apierrors.ErrImageFilenameTooLong)
+	})
+
+	Convey("Given an image with a state that does not correspond to any expected state, it fails to validate with the expected error", t, func() {
+		image := models.Image{
+			State: "wrong",
+		}
+		err := image.Validate()
+		So(err, ShouldResemble, apierrors.ErrImageInvalidState)
+	})
+
+	Convey("Given a fully populated valid image, it is successfully validated", t, func() {
+		image := models.Image{
+			ID:           "123",
+			CollectionID: "456",
+			State:        models.StatePublished.String(),
+			Filename:     "image-file-name",
+			License: &models.License{
+				Title: "testLicense",
+				Href:  "http://testLicense.co.uk",
+			},
+			Upload: &models.Upload{
+				Path: "image-upload-path",
+			},
+			Type: "icon",
+			Downloads: map[string]map[string]models.Download{
+				"png": {"resolution": {}},
+			},
+		}
+		err := image.Validate()
+		So(err, ShouldBeNil)
+	})
+
+}
+
+func TestImageStateTransitionAllowed(t *testing.T) {
+	Convey("Given an image in created state", t, func() {
+		image := models.Image{
+			State: models.StateCreated.String(),
+		}
+		validateTransitionsFromCreated(image)
+	})
+
+	Convey("Given an image with a wrong state value, then no transition is allowed", t, func() {
+		image := models.Image{State: "wrong"}
+		validateTransitionsFromCreated(image)
+	})
+
+	Convey("Given an image without state, then created state is assumed when checking for transitions", t, func() {
+		image := models.Image{}
+		validateTransitionsFromCreated(image)
+	})
+}
+
+func validateTransitionsFromCreated(image models.Image) {
+	Convey("Then an allowed transition is successfully checked", func() {
+		So(image.StateTransitionAllowed(models.StateCreated.String()), ShouldBeTrue)
+	})
+	Convey("Then a forbidden transition to a valid state is not allowed", func() {
+		So(image.StateTransitionAllowed(models.StatePublished.String()), ShouldBeFalse)
+	})
+	Convey("Then a transition to an invalid state is not allowed", func() {
+		So(image.StateTransitionAllowed("wrong"), ShouldBeFalse)
+	})
+}

--- a/models/state_test.go
+++ b/models/state_test.go
@@ -1,0 +1,51 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-image-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestStateValidation(t *testing.T) {
+
+	Convey("Given a Created State, then only transitions to created, uploaded and deleted are allowed", t, func() {
+		So(models.StateCreated.TransitionAllowed(models.StateCreated), ShouldBeTrue)
+		So(models.StateCreated.TransitionAllowed(models.StateUploaded), ShouldBeTrue)
+		So(models.StateCreated.TransitionAllowed(models.StatePublishing), ShouldBeFalse)
+		So(models.StateCreated.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateCreated.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+	})
+
+	Convey("Given a Uploaded State, then only transitions to uploaded, publishing and deleted are allowed", t, func() {
+		So(models.StateUploaded.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StateUploaded.TransitionAllowed(models.StateUploaded), ShouldBeTrue)
+		So(models.StateUploaded.TransitionAllowed(models.StatePublishing), ShouldBeTrue)
+		So(models.StateUploaded.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateUploaded.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+	})
+
+	Convey("Given a Publishing State, then only transitions to publishing, uploaded, published and deleted are allowed", t, func() {
+		So(models.StatePublishing.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StatePublishing.TransitionAllowed(models.StateUploaded), ShouldBeTrue)
+		So(models.StatePublishing.TransitionAllowed(models.StatePublishing), ShouldBeTrue)
+		So(models.StatePublishing.TransitionAllowed(models.StatePublished), ShouldBeTrue)
+		So(models.StatePublishing.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+	})
+
+	Convey("Given a Published State, then only transitions to published and deleted are allowed", t, func() {
+		So(models.StatePublished.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StatePublished.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
+		So(models.StatePublished.TransitionAllowed(models.StatePublishing), ShouldBeFalse)
+		So(models.StatePublished.TransitionAllowed(models.StatePublished), ShouldBeTrue)
+		So(models.StatePublished.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+	})
+
+	Convey("Given a Deleted State, then no transitions are allowed", t, func() {
+		So(models.StateDeleted.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StatePublishing), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StateDeleted), ShouldBeFalse)
+	})
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -212,6 +212,7 @@ definitions:
         type: string
         description: "Collection unique identifier corresponding to this image"
         example: "5557dcd9-bf58-4a67-94f7-2343569834cc"
+        required: true
       filename:
         type: string
         description: "Image's file name. According to SEO recommendations, the name should not be longer than 5 words. And it should not include extension because multiple extensions for the same image might be available as download variants."
@@ -246,7 +247,6 @@ definitions:
         type: string
         description: "Collection unique identifier corresponding to this image"
         example: "5557dcd9-bf58-4a67-94f7-2343569834cc"
-        required: true
       state:
         type: string
         enum:
@@ -257,7 +257,6 @@ definitions:
           - deleted
         description: "The state of the image"
         example: "published"
-        required: true
       filename:
         type: string
         description: "Image's file name. According to SEO recommendations, the name should not be longer than 5 words. And it should not include extension because multiple extensions for the same image might be available as download variants."


### PR DESCRIPTION
### What

- `PUT /images/{id}` now only updates the image with the values provided in the body
- If the update results in a no-op, MongoDB is not contacted again
- Added unit tests for the changes, and the models validations.

### How to review

- Make sure code changes make sense
- Unit tests should pass

### Who can review

Anyone.