### PR TITLE
Made collection_id query parameter optional in GET /images

### DIFF
--- a/api/image.go
+++ b/api/image.go
@@ -78,10 +78,7 @@ func (api *API) GetImagesHandler(w http.ResponseWriter, req *http.Request) {
 
 	// validate collection ID from header matches collection ID from query param
 	colID := req.URL.Query().Get("collection_id")
-	if colID != hColID {
-		handleError(ctx, w, apierrors.ErrColIDMismatch, logdata)
-		return
-	}
+	logdata["collection_id"] = colID
 
 	// get images from MongoDB for the requested collection
 	items, err := api.mongoDB.GetImages(ctx, colID)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -66,9 +66,11 @@ func (m *Mongo) GetImages(ctx context.Context, collectionID string) ([]models.Im
 	defer s.Close()
 	log.Event(ctx, "getting images for collectionID", log.Data{"collectionID": collectionID})
 
-	// Filter by collectionID
+	// Filter by collectionID, if provided
 	colIDFilter := make(bson.M)
-	colIDFilter["collection_id"] = collectionID
+	if collectionID != "" {
+		colIDFilter["collection_id"] = collectionID
+	}
 
 	iter := s.DB(m.Database).C(imagesCol).Find(colIDFilter).Iter()
 	defer func() {


### PR DESCRIPTION
### What

- Made `collection_id` query parameter optional in `GET /images`.
  - If not provided, all images will be returned
  - `Collection-Id` header and `collection_id` may have different values.
- Modified unit tests accordingly

### How to review

- Make sure code changes make sense
- Unit tests should pass

### Who can review

Anyone