### PR TITLE
Feature/put return updated image

### DIFF
--- a/api/image_test.go
+++ b/api/image_test.go
@@ -590,7 +590,7 @@ func TestUpdateImageHandler(t *testing.T) {
 			So(*mongoDBMock.UpdateImageCalls()[0].Image, ShouldResemble, createdImageNoCollectionID)
 		})
 
-		Convey("Calling update image which results in a no-op dynamodb update, results in 200 OK response, nothing is updated in mongoDB, and getImage is called only once", func() {
+		Convey("Calling update image which results in a no-op mongoDB update, results in 200 OK response, nothing is updated in mongoDB, and getImage is called only once", func() {
 			r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:24700/images/%s", "idNoop"), bytes.NewBufferString(emptyUploadPayload))
 			r = r.WithContext(context.WithValue(r.Context(), dphttp.FlorenceIdentityKey, testUserAuthToken))
 			w := httptest.NewRecorder()

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -15,10 +15,10 @@ import (
 // MongoServer defines the required methods from MongoDB
 type MongoServer interface {
 	Close(ctx context.Context) error
-	Checker(ctx context.Context, state *healthcheck.CheckState) error
-	GetImages(ctx context.Context, collectionID string) ([]models.Image, error)
-	GetImage(ctx context.Context, id string) (*models.Image, error)
-	UpdateImage(ctx context.Context, id string, image *models.Image) error
+	Checker(ctx context.Context, state *healthcheck.CheckState) (err error)
+	GetImages(ctx context.Context, collectionID string) (images []models.Image, err error)
+	GetImage(ctx context.Context, id string) (image *models.Image, err error)
+	UpdateImage(ctx context.Context, id string, image *models.Image) (didChange bool, err error)
 	UpsertImage(ctx context.Context, id string, image *models.Image) (err error)
 }
 

--- a/api/mock/mongo.go
+++ b/api/mock/mongo.go
@@ -42,7 +42,7 @@ var _ api.MongoServer = &MongoServerMock{}
 //             GetImagesFunc: func(ctx context.Context, collectionID string) ([]models.Image, error) {
 // 	               panic("mock out the GetImages method")
 //             },
-//             UpdateImageFunc: func(ctx context.Context, id string, image *models.Image) error {
+//             UpdateImageFunc: func(ctx context.Context, id string, image *models.Image) (bool, error) {
 // 	               panic("mock out the UpdateImage method")
 //             },
 //             UpsertImageFunc: func(ctx context.Context, id string, image *models.Image) error {
@@ -68,7 +68,7 @@ type MongoServerMock struct {
 	GetImagesFunc func(ctx context.Context, collectionID string) ([]models.Image, error)
 
 	// UpdateImageFunc mocks the UpdateImage method.
-	UpdateImageFunc func(ctx context.Context, id string, image *models.Image) error
+	UpdateImageFunc func(ctx context.Context, id string, image *models.Image) (bool, error)
 
 	// UpsertImageFunc mocks the UpsertImage method.
 	UpsertImageFunc func(ctx context.Context, id string, image *models.Image) error
@@ -259,7 +259,7 @@ func (mock *MongoServerMock) GetImagesCalls() []struct {
 }
 
 // UpdateImage calls UpdateImageFunc.
-func (mock *MongoServerMock) UpdateImage(ctx context.Context, id string, image *models.Image) error {
+func (mock *MongoServerMock) UpdateImage(ctx context.Context, id string, image *models.Image) (bool, error) {
 	if mock.UpdateImageFunc == nil {
 		panic("MongoServerMock.UpdateImageFunc: method is nil but MongoServer.UpdateImage was just called")
 	}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,7 +23,7 @@ paths:
       tags:
       - "image"
       summary: "Get images filtered by collection id"
-      description: "Returns a list of images metadata filtered by a compulsory query parameter defining the collection ID"
+      description: "Returns a list of images metadata filtered by an optional query parameter defining the collection ID"
       parameters:
       - $ref: '#/parameters/collection_id'
       produces:
@@ -32,11 +32,11 @@ paths:
       - FlorenceAPIKey: []
       responses:
         200:
-          description: "A json object containing images which correspond to the provided collection ID"
+          description: "A json object containing a list of images"
           schema:
             $ref: '#/definitions/Images'
         400:
-          description: "Invalid request, collection id was incorrect"
+          description: "Invalid request"
         401:
           $ref: '#/responses/Unauthenticated'
         403:
@@ -47,7 +47,7 @@ paths:
       tags:
       - "image"
       summary: "Create a new image metadata entry"
-      description: "Creates a new image metadata entry corresponding to the provided body in this request."
+      description: "Creates a new image metadata entry corresponding to the provided body in this request. A new ID will be generated for the image, and it will be set to `created` state."
       parameters:
       - $ref: '#/parameters/new_image'
       produces:
@@ -56,7 +56,7 @@ paths:
       - FlorenceAPIKey: []
       responses:
         201:
-          description: "The image metadata was correctly created and a json object containing the new image information is returned, including a newly generated id"
+          description: "The image metadata was correctly created and a json object containing the new image information is returned. The new image will be in 'created' state and its id will be newly generated."
           schema:
             $ref: '#/definitions/Image'
         400:
@@ -103,7 +103,7 @@ paths:
       tags:
       - "image"
       summary: "Update an image metadata entry"
-      description: "Updates an image metadata entry whose id matches the id provided as path parameter"
+      description: "Updates an existing image metadata entry whose id matches the id provided as path parameter. Only the provided fields will be used to overwrite an existing image, creating them if they did not already exist, and not overwriting any field that is not provided."
       parameters:
       - $ref: '#/parameters/image_id'
       - $ref: '#/parameters/image'
@@ -120,8 +120,7 @@ paths:
         400:
           description: |
             Invalid request, reasons can be one of the following:
-              * image id was incorrect
-              * collection id was incorrect
+              * image id in body, if provided, did not match the path parameter
               * malformed body
               * provided image had an invalid parameter
         401:
@@ -207,12 +206,13 @@ definitions:
   NewImage:
     type: object
     description: "New Image metadata model, used to create new images. The image ID will be created by image API, and the state will be set to 'created' at creation time."
+    required:
+      - "collection_id"
     properties:
       collection_id:
         type: string
         description: "Collection unique identifier corresponding to this image"
         example: "5557dcd9-bf58-4a67-94f7-2343569834cc"
-        required: true
       filename:
         type: string
         description: "Image's file name. According to SEO recommendations, the name should not be longer than 5 words. And it should not include extension because multiple extensions for the same image might be available as download variants."
@@ -348,7 +348,6 @@ parameters:
   collection_id:
     name: collection_id
     description: "A unique id for a collection to filter on"
-    required: true
     in: query
     type: string
     
@@ -362,7 +361,7 @@ parameters:
 
   new_image:
     name: new_image
-    description: "A valid image model at creation time, which might define the same fields as an existing image model, except for the id and state"
+    description: "A valid image model at creation time. Only a subset of the full image model will be considered."
     in: body
     required: true
     schema:


### PR DESCRIPTION
### What

- Collection-Id header is now never validated (only logged if provided)
  - `GET image/id` : removed validation of unpublished + collection-Id
  - `PUT image/id` : removed validation that provided image update and collecion-Id header match
  - `PUT image/id` : removed validation that image in MongoDB and collection-Id header match
- `PUT image/id` Return updated image in the response body
  - Extra call to MongoDB, only if the image was updated
- Changed tests accordingly
- Updated swagger spec accordingly

### How to review

- Make sure changes make sense
- Unit tests should pass

### Who can review

Anyone