### PR TITLE
Create put publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 dp-image-api
 ================
-TODO
+Digital Publishing Image API
 
 ### Getting started
 
@@ -12,12 +12,21 @@ TODO
 
 ### Configuration
 
-| Environment variable         | Default   | Description
-| ---------------------------- | --------- | -----------
-| BIND_ADDR                    | :24700    | The host and port to bind to
-| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s        | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 30s       | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| Environment variable         | Default               | Description
+| ---------------------------- | --------------------- | -----------
+| BIND_ADDR                    | :24700                | The host and port to bind to
+| KAFKA_ADDR                   | localhost:9092        | The list of kafka broker hosts (publishing mode only)
+| KAFKA_MAX_BYTES              | 2000000               | Maximum number of bytes in a kafka message (publishing mode only)
+| IMAGE_UPLOADED_TOPIC         | image-uploaded        | The kafka topic that will be produced by this service for image uploading events (publishing mode only)
+| STATIC_FILE_PUBLISHED_TOPIC  | static-file-published | The kafka topic that will be produced by this service for image publishing events (publishing mode only)
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                    | The graceful shutdown timeout in seconds (`time.Duration` format)
+| HEALTHCHECK_INTERVAL         | 30s                   | Time between self-healthchecks (`time.Duration` format)
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                   | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| IS_PUBLISHING                | true                  | Determines if the instance is publishing or not
+| ZEBEDEE_URL                  | http://localhost:8082 | The URL of zebedee (publishing mode only)
+| MONGODB_BIND_ADDR            | localhost:27017       | The MongoDB bind address
+| MONGODB_COLLECTION           | images                | The MongoDB images database
+| MONGODB_DATABASE             | images                | MongoDB collection
 
 ### Contributing
 

--- a/api/api.go
+++ b/api/api.go
@@ -42,7 +42,7 @@ func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHand
 		r.HandleFunc("/images", auth.Require(dpauth.Permissions{Read: true}, api.GetImagesHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Read: true}, api.GetImageHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateImageHandler)).Methods(http.MethodPut)
-		r.HandleFunc("/images/{id}/publish", auth.Require(dpauth.Permissions{Update: true}, api.PublishImageHandler)).Methods(http.MethodPut)
+		r.HandleFunc("/images/{id}/publish", auth.Require(dpauth.Permissions{Update: true}, api.PublishImageHandler)).Methods(http.MethodPost)
 	} else {
 		r.HandleFunc("/images", api.GetImagesHandler).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", api.GetImageHandler).Methods(http.MethodGet)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -45,7 +45,7 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
 			})
 
 			Convey("And auth handler is called once per route with the expected permissions", func() {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -44,7 +44,7 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeTrue)
 			})
 
 			Convey("And auth handler is called once per route with the expected permissions", func() {
@@ -72,7 +72,7 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeFalse)
-				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeFalse)
+				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeFalse)
 			})
 
 			Convey("And no auth permissions are required", func() {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -36,8 +36,9 @@ func TestSetup(t *testing.T) {
 
 		Convey("When created in Publishing mode", func() {
 			cfg := &config.Config{IsPublishing: true}
-			kafkaProducerMock := kafkatest.NewMessageProducer(true)
-			api := api.Setup(ctx, cfg, r, authHandlerMock, &mock.MongoServerMock{}, kafkaProducerMock)
+			uploadedKafkaProducer := kafkatest.NewMessageProducer(true)
+			publishedKafkaProducer := kafkatest.NewMessageProducer(true)
+			api := api.Setup(ctx, cfg, r, authHandlerMock, &mock.MongoServerMock{}, uploadedKafkaProducer, publishedKafkaProducer)
 
 			Convey("Then the following routes should have been added", func() {
 				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeTrue)
@@ -64,8 +65,9 @@ func TestSetup(t *testing.T) {
 
 		Convey("When created in Web mode", func() {
 			cfg := &config.Config{IsPublishing: false}
-			kafkaProducerMock := kafkatest.NewMessageProducer(true)
-			api := api.Setup(ctx, cfg, r, authHandlerMock, &mock.MongoServerMock{}, kafkaProducerMock)
+			uploadedKafkaProducer := kafkatest.NewMessageProducer(true)
+			publishedKafkaProducer := kafkatest.NewMessageProducer(true)
+			api := api.Setup(ctx, cfg, r, authHandlerMock, &mock.MongoServerMock{}, uploadedKafkaProducer, publishedKafkaProducer)
 
 			Convey("Then only the get routes should have been added", func() {
 				So(hasRoute(api.Router, "/images", http.MethodGet), ShouldBeTrue)
@@ -86,8 +88,9 @@ func TestClose(t *testing.T) {
 	Convey("Given an API instance", t, func() {
 		r := mux.NewRouter()
 		ctx := context.Background()
-		kafkaProducerMock := kafkatest.NewMessageProducer(true)
-		a := api.Setup(ctx, &config.Config{}, r, &mock.AuthHandlerMock{}, &mock.MongoServerMock{}, kafkaProducerMock)
+		uploadedKafkaProducer := kafkatest.NewMessageProducer(true)
+		publishedKafkaProducer := kafkatest.NewMessageProducer(true)
+		a := api.Setup(ctx, &config.Config{}, r, &mock.AuthHandlerMock{}, &mock.MongoServerMock{}, uploadedKafkaProducer, publishedKafkaProducer)
 
 		Convey("When the api is closed any dependencies are closed also", func() {
 			err := a.Close(ctx)
@@ -98,10 +101,10 @@ func TestClose(t *testing.T) {
 }
 
 // GetAPIWithMocks also used in other tests
-func GetAPIWithMocks(cfg *config.Config, mongoDbMock *mock.MongoServerMock, authHandlerMock *mock.AuthHandlerMock, kafkaProducerMock kafka.IProducer) *api.API {
+func GetAPIWithMocks(cfg *config.Config, mongoDbMock *mock.MongoServerMock, authHandlerMock *mock.AuthHandlerMock, uploadedKafkaProducerMock, publishedKafkaProducerMock kafka.IProducer) *api.API {
 	mu.Lock()
 	defer mu.Unlock()
-	return api.Setup(testContext, cfg, mux.NewRouter(), authHandlerMock, mongoDbMock, kafkaProducerMock)
+	return api.Setup(testContext, cfg, mux.NewRouter(), authHandlerMock, mongoDbMock, uploadedKafkaProducerMock, publishedKafkaProducerMock)
 }
 
 func hasRoute(r *mux.Router, path, method string) bool {

--- a/api/image.go
+++ b/api/image.go
@@ -255,12 +255,12 @@ func (api *API) PublishImageHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO Send kafka message
-
 	// Update image in mongo DB
 	_, err = api.mongoDB.UpdateImage(ctx, id, imageUpdate)
 	if err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
+
+	// TODO Send kafka message
 }

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -326,7 +326,7 @@ func TestCreateImageHandler(t *testing.T) {
 		}
 		imageApi := GetAPIWithMocks(cfg, mongoDBMock, authHandlerMock, kafkaStubProducer, kafkaStubProducer)
 
-		Convey("When a new image is posted a 501 InternalServerError status code is returned", func() {
+		Convey("When a new image is posted a 500 InternalServerError status code is returned", func() {
 			r := httptest.NewRequest(http.MethodPost, "http://localhost:24700/images", bytes.NewBufferString(
 				fmt.Sprintf(newImagePayloadFmt, testCollectionID1, "some-image-name")))
 			r = r.WithContext(context.WithValue(r.Context(), dphttp.FlorenceIdentityKey, testUserAuthToken))
@@ -848,7 +848,7 @@ func TestPublishImageHandler(t *testing.T) {
 			imageApi := GetAPIWithMocks(cfg, mongoDBMock, authHandlerMock, kafkaStubProducer, publishedProducer)
 
 			Convey("Calling 'publish image' results in 200 OK response with the expected image state update to mongoDB and the message sent to kafka producer", func() {
-				r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
+				r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
 				r = r.WithContext(context.WithValue(r.Context(), dphttp.FlorenceIdentityKey, testUserAuthToken))
 				r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID1))
 				w := httptest.NewRecorder()
@@ -879,7 +879,7 @@ func TestPublishImageHandler(t *testing.T) {
 			imageApi := GetAPIWithMocks(cfg, mongoDBMock, authHandlerMock, kafkaStubProducer, kafkaStubProducer)
 
 			Convey("Calling 'publish image' results in 403 Forbidden response", func() {
-				r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
+				r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
 				r = r.WithContext(context.WithValue(r.Context(), dphttp.FlorenceIdentityKey, testUserAuthToken))
 				r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID1))
 				w := httptest.NewRecorder()
@@ -899,7 +899,7 @@ func TestPublishImageHandler(t *testing.T) {
 			imageApi := GetAPIWithMocks(cfg, mongoDBMock, authHandlerMock, kafkaStubProducer, kafkaStubProducer)
 
 			Convey("Calling 'publish image' results in 500 response", func() {
-				r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
+				r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
 				r = r.WithContext(context.WithValue(r.Context(), dphttp.FlorenceIdentityKey, testUserAuthToken))
 				w := httptest.NewRecorder()
 				imageApi.Router.ServeHTTP(w, r)
@@ -921,7 +921,7 @@ func TestPublishImageHandler(t *testing.T) {
 			imageApi := GetAPIWithMocks(cfg, mongoDBMock, authHandlerMock, kafkaStubProducer, kafkaStubProducer)
 
 			Convey("Calling 'publish image' results in 500 response", func() {
-				r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
+				r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
 				r = r.WithContext(context.WithValue(r.Context(), dphttp.FlorenceIdentityKey, testUserAuthToken))
 				r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID1))
 				w := httptest.NewRecorder()

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -19,4 +19,5 @@ var (
 	ErrImageAlreadyPublished          = errors.New("image is already published")
 	ErrImageInvalidState              = errors.New("image state is not a valid state name")
 	ErrImageStateTransitionNotAllowed = errors.New("image state transition not allowed")
+	ErrImagePublishWrongEndpoint      = errors.New("wrong endpoint to publish images. Please use 'PUT /images/{id}/publish' instead")
 )

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -19,5 +19,5 @@ var (
 	ErrImageAlreadyPublished          = errors.New("image is already published")
 	ErrImageInvalidState              = errors.New("image state is not a valid state name")
 	ErrImageStateTransitionNotAllowed = errors.New("image state transition not allowed")
-	ErrImagePublishWrongEndpoint      = errors.New("wrong endpoint to publish images. Please use 'PUT /images/{id}/publish' instead")
+	ErrImagePublishWrongEndpoint      = errors.New("wrong endpoint to publish images. Please use 'POST /images/{id}/publish' instead")
 )

--- a/event/event.go
+++ b/event/event.go
@@ -5,3 +5,8 @@ type ImageUploaded struct {
 	Path    string `avro:"path"`
 	ImageID string `avro:"image_id"`
 }
+
+// ImagePublished provides an avro structure for an image published event
+type ImagePublished struct {
+	ImageID string `avro:"image_id"`
+}

--- a/event/producer.go
+++ b/event/producer.go
@@ -25,17 +25,28 @@ func NewAvroProducer(outputChannel chan []byte, marshaller Marshaller) *AvroProd
 	}
 }
 
-// ImageUploaded produces a new Image Uploaded event.
+// ImageUploaded produces a new ImageUploaded event.
 func (producer *AvroProducer) ImageUploaded(event *ImageUploaded) error {
 	if event == nil {
 		return errors.New("event required but was nil")
 	}
+	return producer.marshalAndSendEvent(event)
+}
+
+// ImagePublished produces a new ImagePublished event.
+func (producer *AvroProducer) ImagePublished(event *ImagePublished) error {
+	if event == nil {
+		return errors.New("event required but was nil")
+	}
+	return producer.marshalAndSendEvent(event)
+}
+
+//marshalAndSendEvent is a generic function that marshals avro events and sends them to the output channel of the producer
+func (producer *AvroProducer) marshalAndSendEvent(event interface{}) error {
 	bytes, err := producer.marshaller.Marshal(event)
 	if err != nil {
 		return err
 	}
-
 	producer.out <- bytes
-
 	return nil
 }

--- a/models/state.go
+++ b/models/state.go
@@ -12,10 +12,13 @@ const (
 	StateImporting
 	StateImported
 	StatePublished
+	StateCompleted
 	StateDeleted
+	StateFailedImport
+	StateFailedPublish
 )
 
-var stateValues = []string{"created", "uploaded", "importing", "imported", "published", "deleted"}
+var stateValues = []string{"created", "uploaded", "importing", "imported", "published", "completed", "deleted", "failed_import", "failed_publish"}
 
 // String returns the string representation of a state
 func (s State) String() string {
@@ -51,7 +54,7 @@ func (s State) TransitionAllowed(target State) bool {
 		}
 	case StateImporting:
 		switch target {
-		case StateImporting, StateImported, StateDeleted:
+		case StateImporting, StateImported, StateFailedImport, StateDeleted:
 			return true
 		default:
 			return false
@@ -65,7 +68,28 @@ func (s State) TransitionAllowed(target State) bool {
 		}
 	case StatePublished:
 		switch target {
-		case StatePublished, StateDeleted:
+		case StatePublished, StateCompleted, StateFailedPublish, StateDeleted:
+			return true
+		default:
+			return false
+		}
+	case StateCompleted:
+		switch target {
+		case StateCompleted, StateDeleted:
+			return true
+		default:
+			return false
+		}
+	case StateFailedImport:
+		switch target {
+		case StateFailedImport, StateDeleted:
+			return true
+		default:
+			return false
+		}
+	case StateFailedPublish:
+		switch target {
+		case StateFailedPublish, StateDeleted:
 			return true
 		default:
 			return false

--- a/models/state.go
+++ b/models/state.go
@@ -9,12 +9,13 @@ type State int
 const (
 	StateCreated State = iota
 	StateUploaded
-	StatePublishing
+	StateImporting
+	StateImported
 	StatePublished
 	StateDeleted
 )
 
-var stateValues = []string{"created", "uploaded", "publishing", "published", "deleted"}
+var stateValues = []string{"created", "uploaded", "importing", "imported", "published", "deleted"}
 
 // String returns the string representation of a state
 func (s State) String() string {
@@ -43,14 +44,21 @@ func (s State) TransitionAllowed(target State) bool {
 		}
 	case StateUploaded:
 		switch target {
-		case StateUploaded, StatePublishing, StateDeleted:
+		case StateUploaded, StateImporting, StateDeleted:
 			return true
 		default:
 			return false
 		}
-	case StatePublishing:
+	case StateImporting:
 		switch target {
-		case StatePublishing, StatePublished, StateUploaded, StateDeleted:
+		case StateImporting, StateImported, StateDeleted:
+			return true
+		default:
+			return false
+		}
+	case StateImported:
+		switch target {
+		case StateImported, StatePublished, StateDeleted:
 			return true
 		default:
 			return false

--- a/models/state_test.go
+++ b/models/state_test.go
@@ -12,31 +12,44 @@ func TestStateValidation(t *testing.T) {
 	Convey("Given a Created State, then only transitions to created, uploaded and deleted are allowed", t, func() {
 		So(models.StateCreated.TransitionAllowed(models.StateCreated), ShouldBeTrue)
 		So(models.StateCreated.TransitionAllowed(models.StateUploaded), ShouldBeTrue)
-		So(models.StateCreated.TransitionAllowed(models.StatePublishing), ShouldBeFalse)
+		So(models.StateCreated.TransitionAllowed(models.StateImporting), ShouldBeFalse)
+		So(models.StateCreated.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StateCreated.TransitionAllowed(models.StatePublished), ShouldBeFalse)
 		So(models.StateCreated.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
 	})
 
-	Convey("Given a Uploaded State, then only transitions to uploaded, publishing and deleted are allowed", t, func() {
+	Convey("Given a Uploaded State, then only transitions to uploaded, importing and deleted are allowed", t, func() {
 		So(models.StateUploaded.TransitionAllowed(models.StateCreated), ShouldBeFalse)
 		So(models.StateUploaded.TransitionAllowed(models.StateUploaded), ShouldBeTrue)
-		So(models.StateUploaded.TransitionAllowed(models.StatePublishing), ShouldBeTrue)
+		So(models.StateUploaded.TransitionAllowed(models.StateImporting), ShouldBeTrue)
+		So(models.StateUploaded.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StateUploaded.TransitionAllowed(models.StatePublished), ShouldBeFalse)
 		So(models.StateUploaded.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
 	})
 
-	Convey("Given a Publishing State, then only transitions to publishing, uploaded, published and deleted are allowed", t, func() {
-		So(models.StatePublishing.TransitionAllowed(models.StateCreated), ShouldBeFalse)
-		So(models.StatePublishing.TransitionAllowed(models.StateUploaded), ShouldBeTrue)
-		So(models.StatePublishing.TransitionAllowed(models.StatePublishing), ShouldBeTrue)
-		So(models.StatePublishing.TransitionAllowed(models.StatePublished), ShouldBeTrue)
-		So(models.StatePublishing.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+	Convey("Given an Importing State, then only transitions to importing, imported and deleted are allowed", t, func() {
+		So(models.StateImporting.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StateImporting.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
+		So(models.StateImporting.TransitionAllowed(models.StateImporting), ShouldBeTrue)
+		So(models.StateImporting.TransitionAllowed(models.StateImported), ShouldBeTrue)
+		So(models.StateImporting.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateImporting.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+	})
+
+	Convey("Given an Imported State, then only transitions to imported, published and deleted are allowed", t, func() {
+		So(models.StateImported.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StateImported.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
+		So(models.StateImported.TransitionAllowed(models.StateImporting), ShouldBeFalse)
+		So(models.StateImported.TransitionAllowed(models.StateImported), ShouldBeTrue)
+		So(models.StateImported.TransitionAllowed(models.StatePublished), ShouldBeTrue)
+		So(models.StateImported.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
 	})
 
 	Convey("Given a Published State, then only transitions to published and deleted are allowed", t, func() {
 		So(models.StatePublished.TransitionAllowed(models.StateCreated), ShouldBeFalse)
 		So(models.StatePublished.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
-		So(models.StatePublished.TransitionAllowed(models.StatePublishing), ShouldBeFalse)
+		So(models.StatePublished.TransitionAllowed(models.StateImporting), ShouldBeFalse)
+		So(models.StatePublished.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StatePublished.TransitionAllowed(models.StatePublished), ShouldBeTrue)
 		So(models.StatePublished.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
 	})
@@ -44,7 +57,8 @@ func TestStateValidation(t *testing.T) {
 	Convey("Given a Deleted State, then no transitions are allowed", t, func() {
 		So(models.StateDeleted.TransitionAllowed(models.StateCreated), ShouldBeFalse)
 		So(models.StateDeleted.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
-		So(models.StateDeleted.TransitionAllowed(models.StatePublishing), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StateImporting), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StateDeleted.TransitionAllowed(models.StatePublished), ShouldBeFalse)
 		So(models.StateDeleted.TransitionAllowed(models.StateDeleted), ShouldBeFalse)
 	})

--- a/models/state_test.go
+++ b/models/state_test.go
@@ -15,7 +15,10 @@ func TestStateValidation(t *testing.T) {
 		So(models.StateCreated.TransitionAllowed(models.StateImporting), ShouldBeFalse)
 		So(models.StateCreated.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StateCreated.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateCreated.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
 		So(models.StateCreated.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StateCreated.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StateCreated.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
 	})
 
 	Convey("Given a Uploaded State, then only transitions to uploaded, importing and deleted are allowed", t, func() {
@@ -24,16 +27,22 @@ func TestStateValidation(t *testing.T) {
 		So(models.StateUploaded.TransitionAllowed(models.StateImporting), ShouldBeTrue)
 		So(models.StateUploaded.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StateUploaded.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateUploaded.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
 		So(models.StateUploaded.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StateUploaded.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StateUploaded.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
 	})
 
-	Convey("Given an Importing State, then only transitions to importing, imported and deleted are allowed", t, func() {
+	Convey("Given an Importing State, then only transitions to importing, imported, failedImport and deleted are allowed", t, func() {
 		So(models.StateImporting.TransitionAllowed(models.StateCreated), ShouldBeFalse)
 		So(models.StateImporting.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
 		So(models.StateImporting.TransitionAllowed(models.StateImporting), ShouldBeTrue)
 		So(models.StateImporting.TransitionAllowed(models.StateImported), ShouldBeTrue)
 		So(models.StateImporting.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateImporting.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
 		So(models.StateImporting.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StateImporting.TransitionAllowed(models.StateFailedImport), ShouldBeTrue)
+		So(models.StateImporting.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
 	})
 
 	Convey("Given an Imported State, then only transitions to imported, published and deleted are allowed", t, func() {
@@ -42,16 +51,34 @@ func TestStateValidation(t *testing.T) {
 		So(models.StateImported.TransitionAllowed(models.StateImporting), ShouldBeFalse)
 		So(models.StateImported.TransitionAllowed(models.StateImported), ShouldBeTrue)
 		So(models.StateImported.TransitionAllowed(models.StatePublished), ShouldBeTrue)
+		So(models.StateImported.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
 		So(models.StateImported.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StateImported.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StateImported.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
 	})
 
-	Convey("Given a Published State, then only transitions to published and deleted are allowed", t, func() {
+	Convey("Given a Published State, then only transitions to published, failedPublish, completed and deleted are allowed", t, func() {
 		So(models.StatePublished.TransitionAllowed(models.StateCreated), ShouldBeFalse)
 		So(models.StatePublished.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
 		So(models.StatePublished.TransitionAllowed(models.StateImporting), ShouldBeFalse)
 		So(models.StatePublished.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StatePublished.TransitionAllowed(models.StatePublished), ShouldBeTrue)
+		So(models.StatePublished.TransitionAllowed(models.StateCompleted), ShouldBeTrue)
 		So(models.StatePublished.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StatePublished.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StatePublished.TransitionAllowed(models.StateFailedPublish), ShouldBeTrue)
+	})
+
+	Convey("Given a Completed State, then only transitions to completed and deleted are allowed", t, func() {
+		So(models.StateCompleted.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StateCompleted.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
+		So(models.StateCompleted.TransitionAllowed(models.StateImporting), ShouldBeFalse)
+		So(models.StateCompleted.TransitionAllowed(models.StateImported), ShouldBeFalse)
+		So(models.StateCompleted.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateCompleted.TransitionAllowed(models.StateCompleted), ShouldBeTrue)
+		So(models.StateCompleted.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StateCompleted.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StateCompleted.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
 	})
 
 	Convey("Given a Deleted State, then no transitions are allowed", t, func() {
@@ -60,6 +87,33 @@ func TestStateValidation(t *testing.T) {
 		So(models.StateDeleted.TransitionAllowed(models.StateImporting), ShouldBeFalse)
 		So(models.StateDeleted.TransitionAllowed(models.StateImported), ShouldBeFalse)
 		So(models.StateDeleted.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
 		So(models.StateDeleted.TransitionAllowed(models.StateDeleted), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StateDeleted.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
+	})
+
+	Convey("Given a FailedImport State, then only transitions to FailedImport and deleted are allowed", t, func() {
+		So(models.StateFailedImport.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StateFailedImport.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
+		So(models.StateFailedImport.TransitionAllowed(models.StateImporting), ShouldBeFalse)
+		So(models.StateFailedImport.TransitionAllowed(models.StateImported), ShouldBeFalse)
+		So(models.StateFailedImport.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateFailedImport.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
+		So(models.StateFailedImport.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StateFailedImport.TransitionAllowed(models.StateFailedImport), ShouldBeTrue)
+		So(models.StateFailedImport.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
+	})
+
+	Convey("Given a FailedPublish State, then only transitions to FailedPublish and deleted are allowed", t, func() {
+		So(models.StateFailedPublish.TransitionAllowed(models.StateCreated), ShouldBeFalse)
+		So(models.StateFailedPublish.TransitionAllowed(models.StateUploaded), ShouldBeFalse)
+		So(models.StateFailedPublish.TransitionAllowed(models.StateImporting), ShouldBeFalse)
+		So(models.StateFailedPublish.TransitionAllowed(models.StateImported), ShouldBeFalse)
+		So(models.StateFailedPublish.TransitionAllowed(models.StatePublished), ShouldBeFalse)
+		So(models.StateFailedPublish.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
+		So(models.StateFailedPublish.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
+		So(models.StateFailedPublish.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StateFailedPublish.TransitionAllowed(models.StateFailedPublish), ShouldBeTrue)
 	})
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -13,7 +13,20 @@ var imageUploadedEvent = `{
   ]
 }`
 
-// ImageUploadedEvent the Avro schema for Image uploaded messages.
+var imagePublishedEvent = `{
+  "type": "record",
+  "name": "image-published",
+  "fields": [
+    {"name": "image_id", "type": "string", "default": ""}
+  ]
+}`
+
+// ImageUploadedEvent is the Avro schema for Image uploaded messages.
 var ImageUploadedEvent = &avro.Schema{
 	Definition: imageUploadedEvent,
+}
+
+// ImagePublishedEvent is the Avro schema for Image published messages.
+var ImagePublishedEvent = &avro.Schema{
+	Definition: imagePublishedEvent,
 }

--- a/service/service.go
+++ b/service/service.go
@@ -72,11 +72,11 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		}
 
 		// Setup the API in publishing
-		a = api.Setup(ctx, cfg, r, auth, mongoDB, uploadedKafkaProducer)
+		a = api.Setup(ctx, cfg, r, auth, mongoDB, uploadedKafkaProducer, publishedKafkaProducer)
 
 	} else {
 		// Setup the API in web mode
-		a = api.Setup(ctx, cfg, r, auth, mongoDB, nil)
+		a = api.Setup(ctx, cfg, r, auth, mongoDB, nil, nil)
 	}
 
 	// Get HealthCheck

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -133,7 +133,7 @@ paths:
           $ref: '#/responses/InternalError'
 
   /images/{image_id}/publish:
-    put:
+    post:
       tags:
       - "image"
       summary: "Publish an image"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -133,7 +133,7 @@ paths:
           $ref: '#/responses/InternalError'
 
   /images/{image_id}/publish:
-    post:
+    put:
       tags:
       - "image"
       summary: "Publish an image"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -126,11 +126,9 @@ paths:
         401:
           $ref: '#/responses/Unauthenticated'
         403:
-          description: "Unauthorised to update image metadata"
+          description: "Unauthorised to update image or cannot be updated because the state transition is not allowed"
         404:
           $ref: '#/responses/NotFound'
-        409:
-          description: "Cannot update an image for the provided collection ID because it is already published"
         500:
           $ref: '#/responses/InternalError'
 
@@ -154,11 +152,9 @@ paths:
         401:
           $ref: '#/responses/Unauthenticated'
         403:
-          description: "Unauthorised to publish image"
+          description: "Unauthorised to publish image or it is in wrong state to be published"
         404:
           $ref: '#/responses/NotFound'
-        409:
-          description: "Cannot publish the image because it is not uploaded yet, or it is has already been published"
         500:
           $ref: '#/responses/InternalError'
 


### PR DESCRIPTION
### What

- Added kafka producer for publish event, with Avro schema and producer, which is used by the api.
- Implemented `PUT /image/{id}/publish` endpoint
  - Produce ImagePublished kafka message on successful image published.
- Return 403 on calls against `PUT /images/{id}` with `{ ... state: published ... }` in body, as we are supposed to use the publish endpoint in order to publish an image.
- Extended state machine with `importing` and `imported` states, and upgraded allowed transitions accordingly.
- Extended tests for new functionality
- Return 403 on state transition not allowed (instead of 409). Changed swagger spec accordingly.
- Updated README to document all config env vars.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone.