### PR TITLE
Feature/update avro schema

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -8,11 +8,6 @@ type ImageUploaded struct {
 
 // ImagePublished provides an avro structure for an image published event
 type ImagePublished struct {
-	Downloads []ImageDownloadPublished `avro:"downloads"`
-}
-
-// ImageDownloadPublished provides an avro structure for each download of an image published event
-type ImageDownloadPublished struct {
 	SrcPath string `avro:"src_path"`
 	DstPath string `avro:"dst_path"`
 }

--- a/event/event.go
+++ b/event/event.go
@@ -8,5 +8,11 @@ type ImageUploaded struct {
 
 // ImagePublished provides an avro structure for an image published event
 type ImagePublished struct {
-	ImageID string `avro:"image_id"`
+	Downloads []ImageDownloadPublished `avro:"downloads"`
+}
+
+// ImageDownloadPublished provides an avro structure for each download of an image published event
+type ImageDownloadPublished struct {
+	SrcPath string `avro:"src_path"`
+	DstPath string `avro:"dst_path"`
 }

--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -74,7 +74,12 @@ func TestAvroProducer(t *testing.T) {
 
 		Convey("When ImagePublished is called on the event producer", func() {
 			event := &event.ImagePublished{
-				ImageID: "myImage",
+				Downloads: []event.ImageDownloadPublished{
+					{
+						SrcPath: "path/private/image.png",
+						DstPath: "path/public/img.png",
+					},
+				},
 			}
 			err := eventProducer.ImagePublished(event)
 
@@ -114,7 +119,12 @@ func TestAvroProducer(t *testing.T) {
 
 		Convey("When ImagePublished is called on the event producer", func() {
 			event := &event.ImagePublished{
-				ImageID: "myImage",
+				Downloads: []event.ImageDownloadPublished{
+					{
+						SrcPath: "path/private/image.png",
+						DstPath: "path/public/img.png",
+					},
+				},
 			}
 			err := eventProducer.ImagePublished(event)
 

--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -74,12 +74,8 @@ func TestAvroProducer(t *testing.T) {
 
 		Convey("When ImagePublished is called on the event producer", func() {
 			event := &event.ImagePublished{
-				Downloads: []event.ImageDownloadPublished{
-					{
-						SrcPath: "path/private/image.png",
-						DstPath: "path/public/img.png",
-					},
-				},
+				SrcPath: "path/private/image.png",
+				DstPath: "path/public/img.png",
 			}
 			err := eventProducer.ImagePublished(event)
 
@@ -119,12 +115,8 @@ func TestAvroProducer(t *testing.T) {
 
 		Convey("When ImagePublished is called on the event producer", func() {
 			event := &event.ImagePublished{
-				Downloads: []event.ImageDownloadPublished{
-					{
-						SrcPath: "path/private/image.png",
-						DstPath: "path/public/img.png",
-					},
-				},
+				SrcPath: "path/private/image.png",
+				DstPath: "path/public/img.png",
 			}
 			err := eventProducer.ImagePublished(event)
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,20 +17,8 @@ var imagePublishedEvent = `{
   "type": "record",
   "name": "image-published",
   "fields": [
-    {
-      "name": "downloads",
-      "type": {
-        "type": "array",
-        "items": {
-          "type": "record",
-          "name": "download-variant",
-          "fields": [
-            {"name": "src_path", "type": "string", "default": ""},
-            {"name": "dst_path", "type": "string", "default": ""}
-          ]
-        }
-      }
-    }
+    {"name": "src_path", "type": "string", "default": ""},
+    {"name": "dst_path", "type": "string", "default": ""}
   ]
 }`
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,7 +17,20 @@ var imagePublishedEvent = `{
   "type": "record",
   "name": "image-published",
   "fields": [
-    {"name": "image_id", "type": "string", "default": ""}
+    {
+      "name": "downloads",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "download-variant",
+          "fields": [
+            {"name": "src_path", "type": "string", "default": ""},
+            {"name": "dst_path", "type": "string", "default": ""}
+          ]
+        }
+      }
+    }
   ]
 }`
 


### PR DESCRIPTION
### What

- updated avro schema to define srcPath and dstPath. This will be the generic format that dp-static-file-publisher will expect (for images or any other file that needs to be processed)
- On image publish, we send one kafka message for each download variant.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Optionally, you can check the kafka consumer handling in static file publisher: https://github.com/ONSdigital/dp-static-file-publisher/pull/10

### Who can review

Anyone