### PR TITLE
Release 0.9.0

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -119,6 +119,7 @@ func handleError(ctx context.Context, w http.ResponseWriter, err error, data log
 			apierrors.ErrImageNoCollectionID,
 			apierrors.ErrImageInvalidState,
 			apierrors.ErrImageDownloadTypeMismatch,
+			apierrors.ErrImageDownloadInvalidState,
 			apierrors.ErrImageIDMismatch:
 			status = http.StatusBadRequest
 		case apierrors.ErrImageAlreadyPublished,
@@ -126,8 +127,9 @@ func handleError(ctx context.Context, w http.ResponseWriter, err error, data log
 			apierrors.ErrImageStateTransitionNotAllowed,
 			apierrors.ErrImageNotImporting,
 			apierrors.ErrImageNotPublished,
+			apierrors.ErrVariantAlreadyExists,
 			apierrors.ErrVariantStateTransitionNotAllowed,
-			apierrors.ErrImageDownloadInvalidState:
+			apierrors.ErrImageDownloadBadInitialState:
 			status = http.StatusForbidden
 		default:
 			status = http.StatusInternalServerError

--- a/api/api.go
+++ b/api/api.go
@@ -45,16 +45,12 @@ func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHand
 		r.HandleFunc("/images", auth.Require(dpauth.Permissions{Create: true}, api.CreateImageHandler)).Methods(http.MethodPost)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Read: true}, api.GetImageHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateImageHandler)).Methods(http.MethodPut)
-		//  TODO           /images/{id}/downloads            GET
 		r.HandleFunc("/images/{id}/downloads", auth.Require(dpauth.Permissions{Update: true}, api.CreateDownloadHandler)).Methods(http.MethodPost)
-		//  TODO           /images/{id}/downloads/{variant}  GET
 		r.HandleFunc("/images/{id}/downloads/{variant}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateDownloadHandler)).Methods(http.MethodPut)
 		r.HandleFunc("/images/{id}/publish", auth.Require(dpauth.Permissions{Update: true}, api.PublishImageHandler)).Methods(http.MethodPost)
 	} else {
 		r.HandleFunc("/images", api.GetImagesHandler).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", api.GetImageHandler).Methods(http.MethodGet)
-		//  TODO           /images/{id}/downloads            GET
-		//  TODO           /images/{id}/downloads/{variant}  GET
 	}
 	return api
 }

--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"github.com/ONSdigital/dp-image-api/url"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -24,15 +25,17 @@ type API struct {
 	auth              AuthHandler
 	uploadProducer    *event.AvroProducer
 	publishedProducer *event.AvroProducer
+	urlBuilder        *url.Builder
 }
 
 // Setup creates the API struct and its endpoints with corresponding handlers
-func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHandler, mongoDB MongoServer, uploadedKafkaProducer, publishedKafkaProducer kafka.IProducer) *API {
+func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHandler, mongoDB MongoServer, uploadedKafkaProducer, publishedKafkaProducer kafka.IProducer, builder *url.Builder) *API {
 
 	api := &API{
-		Router:  r,
-		auth:    auth,
-		mongoDB: mongoDB,
+		Router:     r,
+		auth:       auth,
+		mongoDB:    mongoDB,
+		urlBuilder: builder,
 	}
 
 	if cfg.IsPublishing {

--- a/api/api.go
+++ b/api/api.go
@@ -45,12 +45,14 @@ func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHand
 		r.HandleFunc("/images", auth.Require(dpauth.Permissions{Create: true}, api.CreateImageHandler)).Methods(http.MethodPost)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Read: true}, api.GetImageHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateImageHandler)).Methods(http.MethodPut)
+		r.HandleFunc("/images/{id}/downloads", auth.Require(dpauth.Permissions{Read: true}, api.GetDownloadsHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}/downloads", auth.Require(dpauth.Permissions{Update: true}, api.CreateDownloadHandler)).Methods(http.MethodPost)
 		r.HandleFunc("/images/{id}/downloads/{variant}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateDownloadHandler)).Methods(http.MethodPut)
 		r.HandleFunc("/images/{id}/publish", auth.Require(dpauth.Permissions{Update: true}, api.PublishImageHandler)).Methods(http.MethodPost)
 	} else {
 		r.HandleFunc("/images", api.GetImagesHandler).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", api.GetImageHandler).Methods(http.MethodGet)
+		r.HandleFunc("/images/{id}/downloads", api.GetDownloadsHandler).Methods(http.MethodGet)
 	}
 	return api
 }

--- a/api/api.go
+++ b/api/api.go
@@ -47,12 +47,14 @@ func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHand
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateImageHandler)).Methods(http.MethodPut)
 		r.HandleFunc("/images/{id}/downloads", auth.Require(dpauth.Permissions{Read: true}, api.GetDownloadsHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}/downloads", auth.Require(dpauth.Permissions{Update: true}, api.CreateDownloadHandler)).Methods(http.MethodPost)
+		r.HandleFunc("/images/{id}/downloads/{variant}", auth.Require(dpauth.Permissions{Read: true}, api.GetDownloadHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}/downloads/{variant}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateDownloadHandler)).Methods(http.MethodPut)
 		r.HandleFunc("/images/{id}/publish", auth.Require(dpauth.Permissions{Update: true}, api.PublishImageHandler)).Methods(http.MethodPost)
 	} else {
 		r.HandleFunc("/images", api.GetImagesHandler).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", api.GetImageHandler).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}/downloads", api.GetDownloadsHandler).Methods(http.MethodGet)
+		r.HandleFunc("/images/{id}/downloads/{variant}", api.GetDownloadHandler).Methods(http.MethodGet)
 	}
 	return api
 }

--- a/api/api.go
+++ b/api/api.go
@@ -38,18 +38,20 @@ func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHand
 	if cfg.IsPublishing {
 		api.uploadProducer = event.NewAvroProducer(uploadedKafkaProducer.Channels().Output, schema.ImageUploadedEvent)
 		api.publishedProducer = event.NewAvroProducer(publishedKafkaProducer.Channels().Output, schema.ImagePublishedEvent)
-		r.HandleFunc("/images", auth.Require(dpauth.Permissions{Create: true}, api.CreateImageHandler)).Methods(http.MethodPost)
 		r.HandleFunc("/images", auth.Require(dpauth.Permissions{Read: true}, api.GetImagesHandler)).Methods(http.MethodGet)
+		r.HandleFunc("/images", auth.Require(dpauth.Permissions{Create: true}, api.CreateImageHandler)).Methods(http.MethodPost)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Read: true}, api.GetImageHandler)).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateImageHandler)).Methods(http.MethodPut)
-		r.HandleFunc("/images/{id}/upload", auth.Require(dpauth.Permissions{Update: true}, api.UploadImageHandler)).Methods(http.MethodPost)
+		//  TODO           /images/{id}/downloads            GET
+		r.HandleFunc("/images/{id}/downloads", auth.Require(dpauth.Permissions{Update: true}, api.CreateDownloadHandler)).Methods(http.MethodPost)
+		//  TODO           /images/{id}/downloads/{variant}  GET
+		r.HandleFunc("/images/{id}/downloads/{variant}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateDownloadHandler)).Methods(http.MethodPut)
 		r.HandleFunc("/images/{id}/publish", auth.Require(dpauth.Permissions{Update: true}, api.PublishImageHandler)).Methods(http.MethodPost)
-		r.HandleFunc("/images/{id}/downloads/{variant}", auth.Require(dpauth.Permissions{Update: true}, api.UpdateVariantHandler)).Methods(http.MethodPut)
-		r.HandleFunc("/images/{id}/downloads/{variant}/import", auth.Require(dpauth.Permissions{Update: true}, api.ImportVariantHandler)).Methods(http.MethodPost)
-		r.HandleFunc("/images/{id}/downloads/{variant}/complete", auth.Require(dpauth.Permissions{Update: true}, api.CompleteVariantHandler)).Methods(http.MethodPost)
 	} else {
 		r.HandleFunc("/images", api.GetImagesHandler).Methods(http.MethodGet)
 		r.HandleFunc("/images/{id}", api.GetImageHandler).Methods(http.MethodGet)
+		//  TODO           /images/{id}/downloads            GET
+		//  TODO           /images/{id}/downloads/{variant}  GET
 	}
 	return api
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -64,10 +64,8 @@ func TestSetup(t *testing.T) {
 					Create: false, Read: true, Update: false, Delete: false}) // permissions for GET /images/{id}
 				So(authHandlerMock.RequireCalls()[3].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}
-				// TODO Test for GET /images/{id}/downloads
 				So(authHandlerMock.RequireCalls()[4].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/downloads
-				// TODO Test for GET /images/{id}/downloads/{variant}
 				So(authHandlerMock.RequireCalls()[5].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}/downloads/{variant}
 				So(authHandlerMock.RequireCalls()[6].Required, ShouldResemble, dpauth.Permissions{
@@ -86,9 +84,7 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeFalse)
-				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeFalse)
-				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeFalse)
 			})

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -41,37 +41,35 @@ func TestSetup(t *testing.T) {
 			api := api.Setup(ctx, cfg, r, authHandlerMock, &mock.MongoServerMock{}, uploadedKafkaProducer, publishedKafkaProducer)
 
 			Convey("Then the following routes should have been added", func() {
-				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images", http.MethodGet), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/upload", http.MethodPost), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
+				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}/import", http.MethodPost), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}/complete", http.MethodPost), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
 			})
 
 			Convey("And auth handler is called once per route with the expected permissions", func() {
-				So(len(authHandlerMock.RequireCalls()), ShouldEqual, 9)
+				So(len(authHandlerMock.RequireCalls()), ShouldEqual, 7)
 				So(authHandlerMock.RequireCalls()[0].Required, ShouldResemble, dpauth.Permissions{
-					Create: true, Read: false, Update: false, Delete: false}) // permissions for POST /images
-				So(authHandlerMock.RequireCalls()[1].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: true, Update: false, Delete: false}) // permissions for GET /images
+				So(authHandlerMock.RequireCalls()[1].Required, ShouldResemble, dpauth.Permissions{
+					Create: true, Read: false, Update: false, Delete: false}) // permissions for POST /images
 				So(authHandlerMock.RequireCalls()[2].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: true, Update: false, Delete: false}) // permissions for GET /images/{id}
 				So(authHandlerMock.RequireCalls()[3].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}
+				// TODO Test for GET /images/{id}/downloads
 				So(authHandlerMock.RequireCalls()[4].Required, ShouldResemble, dpauth.Permissions{
-					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/upload
+					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/downloads
+				// TODO Test for GET /images/{id}/downloads/{variant}
 				So(authHandlerMock.RequireCalls()[5].Required, ShouldResemble, dpauth.Permissions{
-					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/publish
-				So(authHandlerMock.RequireCalls()[6].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}/downloads/{variant}
-				So(authHandlerMock.RequireCalls()[7].Required, ShouldResemble, dpauth.Permissions{
-					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/downloads/{variant}/import
-				So(authHandlerMock.RequireCalls()[8].Required, ShouldResemble, dpauth.Permissions{
-					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/downloads/{variant}/complete
+				So(authHandlerMock.RequireCalls()[6].Required, ShouldResemble, dpauth.Permissions{
+					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/publish
 			})
 		})
 
@@ -83,14 +81,14 @@ func TestSetup(t *testing.T) {
 
 			Convey("Then only the get routes should have been added", func() {
 				So(hasRoute(api.Router, "/images", http.MethodGet), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeFalse)
+				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeFalse)
-				So(hasRoute(api.Router, "/images/{id}/upload", http.MethodPost), ShouldBeFalse)
-				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeFalse)
+				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
+				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeFalse)
+				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeFalse)
-				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}/import", http.MethodPost), ShouldBeFalse)
-				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}/complete", http.MethodPost), ShouldBeFalse)
+				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeFalse)
 			})
 
 			Convey("And no auth permissions are required", func() {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -47,13 +47,14 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
 			})
 
 			Convey("And auth handler is called once per route with the expected permissions", func() {
-				So(len(authHandlerMock.RequireCalls()), ShouldEqual, 7)
+				So(len(authHandlerMock.RequireCalls()), ShouldEqual, 8)
 				So(authHandlerMock.RequireCalls()[0].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: true, Update: false, Delete: false}) // permissions for GET /images
 				So(authHandlerMock.RequireCalls()[1].Required, ShouldResemble, dpauth.Permissions{
@@ -63,10 +64,12 @@ func TestSetup(t *testing.T) {
 				So(authHandlerMock.RequireCalls()[3].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}
 				So(authHandlerMock.RequireCalls()[4].Required, ShouldResemble, dpauth.Permissions{
-					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/downloads
+					Create: false, Read: true, Update: false, Delete: false}) // permissions for GET /images/{id}/downloads
 				So(authHandlerMock.RequireCalls()[5].Required, ShouldResemble, dpauth.Permissions{
-					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}/downloads/{variant}
+					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/downloads
 				So(authHandlerMock.RequireCalls()[6].Required, ShouldResemble, dpauth.Permissions{
+					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}/downloads/{variant}
+				So(authHandlerMock.RequireCalls()[7].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/publish
 			})
 		})
@@ -82,6 +85,7 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeFalse)
+				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeFalse)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -47,9 +47,7 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images", http.MethodPost), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeTrue)
-				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodGet), ShouldBeFalse) // TODO Needs to be true when handler implemented
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
 			})

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -49,12 +49,13 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeTrue)
+				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPost), ShouldBeTrue)
 			})
 
 			Convey("And auth handler is called once per route with the expected permissions", func() {
-				So(len(authHandlerMock.RequireCalls()), ShouldEqual, 8)
+				So(len(authHandlerMock.RequireCalls()), ShouldEqual, 9)
 				So(authHandlerMock.RequireCalls()[0].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: true, Update: false, Delete: false}) // permissions for GET /images
 				So(authHandlerMock.RequireCalls()[1].Required, ShouldResemble, dpauth.Permissions{
@@ -68,8 +69,10 @@ func TestSetup(t *testing.T) {
 				So(authHandlerMock.RequireCalls()[5].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/downloads
 				So(authHandlerMock.RequireCalls()[6].Required, ShouldResemble, dpauth.Permissions{
-					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}/downloads/{variant}
+					Create: false, Read: true, Update: false, Delete: false}) // permissions for GET /images/{id}/downloads/{variant}
 				So(authHandlerMock.RequireCalls()[7].Required, ShouldResemble, dpauth.Permissions{
+					Create: false, Read: false, Update: true, Delete: false}) // permissions for PUT /images/{id}/downloads/{variant}
+				So(authHandlerMock.RequireCalls()[8].Required, ShouldResemble, dpauth.Permissions{
 					Create: false, Read: false, Update: true, Delete: false}) // permissions for POST /images/{id}/publish
 			})
 		})
@@ -87,6 +90,7 @@ func TestSetup(t *testing.T) {
 				So(hasRoute(api.Router, "/images/{id}", http.MethodPut), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads", http.MethodPost), ShouldBeFalse)
+				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodGet), ShouldBeTrue)
 				So(hasRoute(api.Router, "/images/{id}/downloads/{variant}", http.MethodPut), ShouldBeFalse)
 				So(hasRoute(api.Router, "/images/{id}/publish", http.MethodPut), ShouldBeFalse)
 			})

--- a/api/image.go
+++ b/api/image.go
@@ -307,8 +307,8 @@ func (api *API) CreateDownloadHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// The high level image needs to be in 'importing' state to allow an update variant operation
-	if image.State != models.StateCreated.String() && image.State != models.StateImporting.String() {
+	// The high level image needs to be in 'uploaded' or 'importing' state to allow an update variant operation
+	if image.State != models.StateUploaded.String() && image.State != models.StateImporting.String() {
 		handleError(ctx, w, apierrors.ErrImageNotImporting, logdata)
 		return
 	}

--- a/api/image.go
+++ b/api/image.go
@@ -64,9 +64,6 @@ func (api *API) GetImagesHandler(w http.ResponseWriter, req *http.Request) {
 		Limit:      len(items),
 	}
 
-	// refresh to populate any fields that are not stored in mongoDB
-	images.Refresh()
-
 	if err := WriteJSONBody(ctx, images, w, logdata); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
@@ -146,9 +143,6 @@ func (api *API) GetImageHandler(w http.ResponseWriter, req *http.Request) {
 		handleError(ctx, w, err, logdata)
 		return
 	}
-
-	// refresh to populate any fields that are not stored in mongoDB
-	image.Refresh()
 
 	if err := WriteJSONBody(ctx, image, w, logdata); err != nil {
 		handleError(ctx, w, err, logdata)
@@ -259,7 +253,6 @@ func (api *API) doUpdateImage(w http.ResponseWriter, req *http.Request, id strin
 			return nil
 		}
 	}
-	updatedImage.Refresh()
 	return updatedImage
 }
 
@@ -393,7 +386,6 @@ func (api *API) UpdateDownloadHandler(w http.ResponseWriter, req *http.Request) 
 			return
 		}
 	}
-	updatedImage.Refresh()
 
 	// return the updated download variant as a json object in the response body
 	if err := WriteJSONBody(ctx, updatedImage.Downloads[variant], w, logdata); err != nil {
@@ -468,7 +460,6 @@ func (api *API) PublishImageHandler(w http.ResponseWriter, req *http.Request) {
 // Note that the private and public paths will be the same, according to the way the URLs are constructed in 'Refresh()' method,
 // using DownloadHrefFmt format "http://<host>/images/<imageID>/<variantName>/<fileName>"
 func generateImagePublishEvents(image *models.Image) (events []*event.ImagePublished, err error) {
-	image.Refresh()
 	for _, variant := range image.Downloads {
 		imgURL, err := url.Parse(variant.Href)
 		if err != nil {

--- a/api/image.go
+++ b/api/image.go
@@ -256,9 +256,6 @@ func (api *API) doUpdateImage(w http.ResponseWriter, req *http.Request, id strin
 	return updatedImage
 }
 
-// GetDownloadsHandler is a handler that returns all the download variant for an image
-// TODO Implement handler
-
 // CreateDownloadHandler is a handler that
 func (api *API) CreateDownloadHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -353,9 +350,6 @@ func (api *API) createLinksForDownload(id, variant string) *models.DownloadLinks
 		Image: image,
 	}
 }
-
-// GetDownloadHandler is a handler that returns an individual download variant
-// TODO Implement handler
 
 // UpdateDownloadHandler is a handler to update an image download variant
 func (api *API) UpdateDownloadHandler(w http.ResponseWriter, req *http.Request) {

--- a/api/image.go
+++ b/api/image.go
@@ -409,10 +409,6 @@ func (api *API) GetDownloadHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	downloadsList := []models.Download{}
-	for _, dl := range image.Downloads {
-		downloadsList = append(downloadsList, dl)
-	}
 	download, found := image.Downloads[variant]
 	if !found {
 		handleError(ctx, w, apierrors.ErrVariantNotFound, logdata)

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -1048,12 +1048,6 @@ func TestUpdateImageHandler(t *testing.T) {
 //	})
 //}
 
-func TestGetDownloadsHandler(t *testing.T) {
-	//TODO Test Get downloads
-	// TEST no image exists
-	// TEST no downloads exist
-}
-
 func TestCreateDownloadHandler(t *testing.T) {
 
 	// Convey - Given an API in publishing mode with an existing image in publishing

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -1050,8 +1050,6 @@ func TestUpdateImageHandler(t *testing.T) {
 
 func TestCreateDownloadHandler(t *testing.T) {
 
-	// Convey - Given an API in publishing mode with an existing image in publishing
-
 	Convey("Given an image API in publishing mode with existing valid images stored in a mongoDB mock", t, func() {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -8,6 +8,7 @@ import (
 var (
 	ErrImageNotFound                    = errors.New("image not found")
 	ErrVariantNotFound                  = errors.New("image download variant not found")
+	ErrVariantAlreadyExists             = errors.New("image download variant already exists")
 	ErrInternalServer                   = errors.New("internal error")
 	ErrUnableToReadMessage              = errors.New("failed to read message body")
 	ErrImageIDMismatch                  = errors.New("image id provided in body does not match 'id' path parameter")
@@ -23,4 +24,5 @@ var (
 	ErrVariantStateTransitionNotAllowed = errors.New("image download variant state transition not allowed")
 	ErrImageDownloadTypeMismatch        = errors.New("image download variant type does not match existing type")
 	ErrImageDownloadInvalidState        = errors.New("image download state is not a valid state name")
+	ErrImageDownloadBadInitialState     = errors.New("image download state is not a valid initial state")
 )

--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ func Get() (*Config, error) {
 
 	cfg := &Config{
 		BindAddr:                   "localhost:24700",
-		ApiURL:                     "http://localhost:24700/",
+		ApiURL:                     "http://localhost:24700",
 		Brokers:                    []string{"localhost:9092"},
 		KafkaMaxBytes:              2000000,
 		ImageUploadedTopic:         "image-uploaded",

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 // Config represents service configuration for dp-image-api
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
+	ApiURL                     string        `envconfig:"IMAGE_API_URL"`
 	Brokers                    []string      `envconfig:"KAFKA_ADDR"`
 	KafkaMaxBytes              int           `envconfig:"KAFKA_MAX_BYTES"`
 	ImageUploadedTopic         string        `envconfig:"IMAGE_UPLOADED_TOPIC"`
@@ -39,6 +40,7 @@ func Get() (*Config, error) {
 
 	cfg := &Config{
 		BindAddr:                   "localhost:24700",
+		ApiURL:                     "http://localhost:24700/",
 		Brokers:                    []string{"localhost:9092"},
 		KafkaMaxBytes:              2000000,
 		ImageUploadedTopic:         "image-uploaded",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@ func TestConfig(t *testing.T) {
 
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, "localhost:24700")
+				So(cfg.ApiURL, ShouldResemble, "http://localhost:24700/")
 				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.KafkaMaxBytes, ShouldEqual, 2000000)
 				So(cfg.ImageUploadedTopic, ShouldEqual, "image-uploaded")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,7 @@ func TestConfig(t *testing.T) {
 
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, "localhost:24700")
-				So(cfg.ApiURL, ShouldResemble, "http://localhost:24700/")
+				So(cfg.ApiURL, ShouldResemble, "http://localhost:24700")
 				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.KafkaMaxBytes, ShouldEqual, 2000000)
 				So(cfg.ImageUploadedTopic, ShouldEqual, "image-uploaded")

--- a/models/image.go
+++ b/models/image.go
@@ -50,6 +50,7 @@ type Upload struct {
 
 // Download represents a download variant model
 type Download struct {
+	ID               string         `bson:"id,omitempty"                 json:"id,omitempty"`
 	Size             *int       `bson:"size,omitempty"               json:"size,omitempty"`
 	Palette          string     `bson:"palette,omitempty"            json:"palette,omitempty"`
 	Type             string     `bson:"type,omitempty"               json:"type,omitempty"`
@@ -57,6 +58,7 @@ type Download struct {
 	Height           *int       `bson:"height,omitempty"             json:"height,omitempty"`
 	Public           bool       `json:"public,omitempty"`
 	Href             string     `json:"href,omitempty"`
+	Links            *DownloadLinks `bson:"links,omitempty"              json:"links,omitempty"`
 	Private          string     `bson:"private,omitempty"            json:"private,omitempty"`
 	State            string     `bson:"state,omitempty"              json:"state,omitempty"`
 	Error            string     `bson:"error,omitempty"              json:"error,omitempty"`
@@ -66,6 +68,9 @@ type Download struct {
 	PublishCompleted *time.Time `bson:"publish_completed,omitempty"  json:"publish_completed,omitempty"`
 }
 
+type DownloadLinks struct {
+	Self  string `bson:"self,omitempty"       json:"self,omitempty"`
+	Image string `bson:"image,omitempty"      json:"image,omitempty"`
 }
 
 // Validate checks that an image struct complies with the filename and state constraints, if provided.
@@ -80,12 +85,6 @@ func (i *Image) Validate() error {
 	if i.State != "" {
 		if _, err := ParseState(i.State); err != nil {
 			return apierrors.ErrImageInvalidState
-		}
-	}
-
-	for _, download := range i.Downloads {
-		if err := download.Validate(); err != nil {
-			return err
 		}
 	}
 
@@ -137,7 +136,7 @@ func (i *Image) AllOtherDownloadsCompleted(variantToIgnore string) bool {
 	return true
 }
 
-// Validate checks that an image struct complies with the state name constraint, if provided.
+// Validate checks that an download struct complies with the state name constraint, if provided.
 func (d *Download) Validate() error {
 	if d.State != "" {
 		if _, err := ParseDownloadState(d.State); err != nil {

--- a/models/image.go
+++ b/models/image.go
@@ -48,24 +48,33 @@ type Upload struct {
 	Path string `bson:"path,omitempty"              json:"path,omitempty"`
 }
 
+// Downloads represents an array of downloads model as it is stored in mongoDB and json representation for API
+type Downloads struct {
+	Count      int        `bson:"count,omitempty"        json:"count"`
+	Offset     int        `bson:"offset_index,omitempty" json:"offset_index"`
+	Limit      int        `bson:"limit,omitempty"        json:"limit"`
+	Items      []Download `bson:"items,omitempty"        json:"items"`
+	TotalCount int        `bson:"total_count,omitempty"  json:"total_count"`
+}
+
 // Download represents a download variant model
 type Download struct {
 	ID               string         `bson:"id,omitempty"                 json:"id,omitempty"`
-	Size             *int       `bson:"size,omitempty"               json:"size,omitempty"`
-	Palette          string     `bson:"palette,omitempty"            json:"palette,omitempty"`
-	Type             string     `bson:"type,omitempty"               json:"type,omitempty"`
-	Width            *int       `bson:"width,omitempty"              json:"width,omitempty"`
-	Height           *int       `bson:"height,omitempty"             json:"height,omitempty"`
-	Public           bool       `json:"public,omitempty"`
-	Href             string     `json:"href,omitempty"`
+	Size             *int           `bson:"size,omitempty"               json:"size,omitempty"`
+	Palette          string         `bson:"palette,omitempty"            json:"palette,omitempty"`
+	Type             string         `bson:"type,omitempty"               json:"type,omitempty"`
+	Width            *int           `bson:"width,omitempty"              json:"width,omitempty"`
+	Height           *int           `bson:"height,omitempty"             json:"height,omitempty"`
+	Public           bool           `json:"public,omitempty"`
+	Href             string         `json:"href,omitempty"`
 	Links            *DownloadLinks `bson:"links,omitempty"              json:"links,omitempty"`
-	Private          string     `bson:"private,omitempty"            json:"private,omitempty"`
-	State            string     `bson:"state,omitempty"              json:"state,omitempty"`
-	Error            string     `bson:"error,omitempty"              json:"error,omitempty"`
-	ImportStarted    *time.Time `bson:"import_started,omitempty"     json:"import_started,omitempty"`
-	ImportCompleted  *time.Time `bson:"import_completed,omitempty"   json:"import_completed,omitempty"`
-	PublishStarted   *time.Time `bson:"publish_started,omitempty"    json:"publish_started,omitempty"`
-	PublishCompleted *time.Time `bson:"publish_completed,omitempty"  json:"publish_completed,omitempty"`
+	Private          string         `bson:"private,omitempty"            json:"private,omitempty"`
+	State            string         `bson:"state,omitempty"              json:"state,omitempty"`
+	Error            string         `bson:"error,omitempty"              json:"error,omitempty"`
+	ImportStarted    *time.Time     `bson:"import_started,omitempty"     json:"import_started,omitempty"`
+	ImportCompleted  *time.Time     `bson:"import_completed,omitempty"   json:"import_completed,omitempty"`
+	PublishStarted   *time.Time     `bson:"publish_started,omitempty"    json:"publish_started,omitempty"`
+	PublishCompleted *time.Time     `bson:"publish_completed,omitempty"  json:"publish_completed,omitempty"`
 }
 
 type DownloadLinks struct {

--- a/models/image_test.go
+++ b/models/image_test.go
@@ -78,50 +78,6 @@ func TestImageAnyDownloadFailed(t *testing.T) {
 	})
 }
 
-func TestImagesRefresh(t *testing.T) {
-	Convey("Given an images struct with an image that contains a download variant", t, func() {
-		images := models.Images{
-			Count:  1,
-			Offset: 0,
-			Limit:  1,
-			Items: []models.Image{
-				{
-					ID:       "imageID",
-					Filename: "myImage.png",
-					State:    models.StateCompleted.String(),
-					Downloads: map[string]models.Download{
-						"original": {
-							State: models.StateDownloadCompleted.String(),
-						},
-					},
-				},
-			},
-		}
-		Convey("Then, refreshing the 'images' refreshes the image and the download variant with the expected values", func() {
-			images.Refresh()
-			So(images, ShouldResemble, models.Images{
-				Count:  1,
-				Offset: 0,
-				Limit:  1,
-				Items: []models.Image{
-					{
-						ID:       "imageID",
-						Filename: "myImage.png",
-						State:    models.StateCompleted.String(),
-						Downloads: map[string]models.Download{
-							"original": {
-								State:  models.StateDownloadCompleted.String(),
-								Href:   "http://static.ons.gov.uk/images/imageID/original/myImage.png",
-								Public: true,
-							},
-						},
-					},
-				},
-			})
-		})
-	})
-}
-
 func TestImageValidation(t *testing.T) {
 
 	Convey("Given an empty image, it is successfully validated", t, func() {
@@ -184,37 +140,6 @@ func TestImageValidation(t *testing.T) {
 	})
 }
 
-func TestImageRefresh(t *testing.T) {
-	Convey("Given a fully populated valid image with a valid download variant, then refreshing the image results in the download variant being refreshed", t, func() {
-
-		image := models.Image{
-			ID:       "imageID",
-			Filename: "myImage.png",
-			State:    models.StateCompleted.String(),
-			Downloads: map[string]models.Download{
-				"original": {
-					State: models.StateDownloadCompleted.String(),
-				},
-			},
-		}
-		Convey("Then, refreshing the image refreshes the download variant with the expected values", func() {
-			image.Refresh()
-			So(image, ShouldResemble, models.Image{
-				ID:       "imageID",
-				Filename: "myImage.png",
-				State:    models.StateCompleted.String(),
-				Downloads: map[string]models.Download{
-					"original": {
-						State:  models.StateDownloadCompleted.String(),
-						Href:   "http://static.ons.gov.uk/images/imageID/original/myImage.png",
-						Public: true,
-					},
-				},
-			})
-		})
-	})
-}
-
 func TestImageStateTransitionAllowed(t *testing.T) {
 	Convey("Given an image in created state", t, func() {
 		image := models.Image{
@@ -270,43 +195,6 @@ func TestDownloadValidation(t *testing.T) {
 		}
 		err := download.Validate()
 		So(err, ShouldBeNil)
-	})
-}
-
-func TestDownloadRefresh(t *testing.T) {
-
-	Convey("Given an array of download variants in any state except completed", t, func() {
-		downloads := []models.Download{
-			{State: models.StateDownloadPending.String()},
-			{State: models.StateDownloadImporting.String()},
-			{State: models.StateDownloadImported.String()},
-			{State: models.StateDownloadPublished.String()},
-			{State: models.StateDownloadFailed.String()},
-		}
-
-		Convey("Then, refreshing the models results in public being false, and the expected href", func() {
-			for _, download := range downloads {
-				state := download.State
-				download.Refresh("imageID", "png_bw", "imageName.png")
-				So(download, ShouldResemble, models.Download{
-					State:  state,
-					Href:   "http://download.ons.gov.uk/images/imageID/png_bw/imageName.png",
-					Public: false,
-				})
-			}
-		})
-	})
-
-	Convey("Given a download variant in completed state", t, func() {
-		download := models.Download{State: models.StateCompleted.String()}
-		Convey("Then, refreshing the model results in public being true, and the expected href", func() {
-			download.Refresh("imageID", "png_bw", "imageName.png")
-			So(download, ShouldResemble, models.Download{
-				State:  models.StateCompleted.String(),
-				Href:   "http://static.ons.gov.uk/images/imageID/png_bw/imageName.png",
-				Public: true,
-			})
-		})
 	})
 }
 

--- a/models/image_test.go
+++ b/models/image_test.go
@@ -102,19 +102,6 @@ func TestImageValidation(t *testing.T) {
 		So(err, ShouldResemble, apierrors.ErrImageInvalidState)
 	})
 
-	Convey("Given an image with an download in an invalid state, it fails to validate with the expected error", t, func() {
-		image := models.Image{
-			State: models.StatePublished.String(),
-			Downloads: map[string]models.Download{
-				"original": {
-					State: "wrong",
-				},
-			},
-		}
-		err := image.Validate()
-		So(err, ShouldResemble, apierrors.ErrImageDownloadInvalidState)
-	})
-
 	Convey("Given a fully populated valid image with a valid download variant, it is successfully validated", t, func() {
 		image := models.Image{
 			ID:           "123",
@@ -129,11 +116,6 @@ func TestImageValidation(t *testing.T) {
 				Path: "image-upload-path",
 			},
 			Type: "icon",
-			Downloads: map[string]models.Download{
-				"original": {
-					State: models.StateDownloadCompleted.String(),
-				},
-			},
 		}
 		err := image.Validate()
 		So(err, ShouldBeNil)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -188,6 +188,9 @@ func createImageUpdateQuery(ctx context.Context, id string, image *models.Image)
 
 	if image.Downloads != nil {
 		for variant, download := range image.Downloads {
+			if download.ID != "" {
+				updates[fmt.Sprintf("downloads.%s.id", variant)] = download.ID
+			}
 			if download.Size != nil {
 				updates[fmt.Sprintf("downloads.%s.size", variant)] = download.Size
 			}
@@ -199,6 +202,9 @@ func createImageUpdateQuery(ctx context.Context, id string, image *models.Image)
 			}
 			if download.Height != nil {
 				updates[fmt.Sprintf("downloads.%s.height", variant)] = download.Height
+			}
+			if download.Links != nil {
+				updates[fmt.Sprintf("downloads.%s.links", variant)] = download.Links
 			}
 			if download.Private != "" {
 				updates[fmt.Sprintf("downloads.%s.private_bucket", variant)] = download.Private

--- a/service/service.go
+++ b/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-image-api/url"
 
 	"github.com/ONSdigital/dp-api-clients-go/health"
 	dpauth "github.com/ONSdigital/dp-authorisation/auth"
@@ -46,6 +47,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	var a *api.API
 
+	urlBuilder := url.NewBuilder(cfg.ApiURL)
 	// The following dependencies will only be initialised if we are in publishing mode
 	var zc *health.Client
 	var auth api.AuthHandler
@@ -72,11 +74,11 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		}
 
 		// Setup the API in publishing
-		a = api.Setup(ctx, cfg, r, auth, mongoDB, uploadedKafkaProducer, publishedKafkaProducer)
+		a = api.Setup(ctx, cfg, r, auth, mongoDB, uploadedKafkaProducer, publishedKafkaProducer, urlBuilder)
 
 	} else {
 		// Setup the API in web mode
-		a = api.Setup(ctx, cfg, r, auth, mongoDB, nil, nil)
+		a = api.Setup(ctx, cfg, r, auth, mongoDB, nil, nil, urlBuilder)
 	}
 
 	// Get HealthCheck

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -171,8 +171,10 @@ paths:
         - $ref: '#/parameters/image_id'
         - $ref: '#/parameters/new_image_download'
       responses:
-        200:
+        201:
           description: "Successfully created download variants."
+          schema:
+            $ref: '#/definitions/ImageDownload'
         400:
           description: "Invalid request"
         401:
@@ -549,15 +551,11 @@ definitions:
         example: 1080
       state:
         type: string
-        description: "The state of this download variant. The high level image will change its state to imported only when all variants are in imported state."
+        description: "The state of this download variant. On creation the only allowed states are pending or importing."
         enum:
           - pending
           - importing
-          - imported
-          - published
-          - completed
-          - failed
-        example: "published"
+        example: "importing"
 
 securityDefinitions:
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -30,6 +30,7 @@ paths:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       responses:
         200:
           description: "A json object containing a list of images"
@@ -54,6 +55,7 @@ paths:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       responses:
         201:
           description: "The image metadata was correctly created and a json object containing the new image information is returned. The new image will be in 'created' state and its id will be newly generated."
@@ -86,6 +88,7 @@ paths:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       responses:
         200:
           description: "A json with the requested image metadata"
@@ -140,6 +143,7 @@ paths:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       parameters:
         - $ref: '#/parameters/image_id'
       responses:
@@ -162,6 +166,7 @@ paths:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       parameters:
         - $ref: '#/parameters/image_id'
         - $ref: '#/parameters/new_image_download'
@@ -187,6 +192,7 @@ paths:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       parameters:
         - $ref: '#/parameters/image_id'
         - $ref: '#/parameters/variant'
@@ -248,6 +254,7 @@ paths:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       responses:
         200:
           description: "The image publishing was successfully requested to Static file publisher."

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -556,6 +556,10 @@ definitions:
           - pending
           - importing
         example: "importing"
+      import_started:
+        type: string
+        description: "Timestamp representation for the importing process start, formatted according to RFC3339"
+        example: "2020-04-26T08:05:52Z"
 
 securityDefinitions:
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -21,15 +21,15 @@ paths:
   /images:
     get:
       tags:
-      - "image"
+        - "image"
       summary: "Get images filtered by collection id"
       description: "Returns a list of images metadata filtered by an optional query parameter defining the collection ID"
       parameters:
-      - $ref: '#/parameters/collection_id'
+        - $ref: '#/parameters/collection_id'
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
+        - FlorenceAPIKey: []
       responses:
         200:
           description: "A json object containing a list of images"
@@ -45,15 +45,15 @@ paths:
           $ref: '#/responses/InternalError'
     post:
       tags:
-      - "image"
+        - "image"
       summary: "Create a new image metadata entry"
       description: "Creates a new image metadata entry corresponding to the provided body in this request. A new ID will be generated for the image, and it will be set to `created` state."
       parameters:
-      - $ref: '#/parameters/new_image'
+        - $ref: '#/parameters/new_image'
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
+        - FlorenceAPIKey: []
       responses:
         201:
           description: "The image metadata was correctly created and a json object containing the new image information is returned. The new image will be in 'created' state and its id will be newly generated."
@@ -77,15 +77,15 @@ paths:
   /images/{image_id}:
     get:
       tags:
-      - "image"
+        - "image"
       summary: "Get an image metadata by its id"
       description: "Returns an image metadata whose id matches the id provided as path parameter"
       parameters:
-      - $ref: '#/parameters/image_id'
+        - $ref: '#/parameters/image_id'
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
+        - FlorenceAPIKey: []
       responses:
         200:
           description: "A json with the requested image metadata"
@@ -101,17 +101,17 @@ paths:
           $ref: '#/responses/InternalError'
     put:
       tags:
-      - "image"
+        - "image"
       summary: "Update an image metadata entry"
       description: "Updates an existing image metadata entry whose id matches the id provided as path parameter. Only the provided fields will be used to overwrite an existing image, creating them if they did not already exist, and not overwriting any field that is not provided."
       parameters:
-      - $ref: '#/parameters/image_id'
-      - $ref: '#/parameters/image'
+        - $ref: '#/parameters/image_id'
+        - $ref: '#/parameters/image'
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
-      - ServiceAPIKey: []
+        - FlorenceAPIKey: []
+        - ServiceAPIKey: []
       responses:
         200:
           description: "A json with the requested image metadata"
@@ -132,74 +132,91 @@ paths:
         500:
           $ref: '#/responses/InternalError'
 
-  /images/{image_id}/upload:
-    post:
+  /images/{image_id}/downloads:
+    get:
       tags:
         - "image"
-      summary: "Upload an image"
-      description: "Supplies the uploaded file location and requests that the image be imported. This call sets the image state to 'uploaded'."
-      parameters:
-        - $ref: '#/parameters/image_id'
-        - $ref: '#/parameters/upload_image'
       produces:
         - "application/json"
       security:
         - FlorenceAPIKey: []
+      parameters:
+        - $ref: '#/parameters/image_id'
       responses:
         200:
-          description: "The image upload was successfully requested to the image importer."
-        400:
-          description: "Invalid request, image id was incorrect"
+          description: "Successfully got download variant."
+          schema:
+            $ref: '#/definitions/ImageDownloads'
         401:
           $ref: '#/responses/Unauthenticated'
         403:
-          description: "Unauthorised to upload image or it is in wrong state to be uploaded"
+          description: "Unauthorised to view images metadata"
         404:
           $ref: '#/responses/NotFound'
         500:
           $ref: '#/responses/InternalError'
-
-  /images/{image_id}/publish:
     post:
       tags:
-      - "image"
-      summary: "Publish an image"
-      description: "Requests an image publishing via the static file publisher, which puts the S3 objects for this image to the static bucket. This call sets the image state to 'publishing'."
-      parameters:
-      - $ref: '#/parameters/image_id'
+        - "image"
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
+        - FlorenceAPIKey: []
+      parameters:
+        - $ref: '#/parameters/image_id'
+        - $ref: '#/parameters/new_image_download'
       responses:
         200:
-          description: "The image publishing was successfully requested to Static file publisher."
+          description: "Successfully created download variants."
         400:
-          description: "Invalid request, image id was incorrect"
+          description: "Invalid request"
         401:
           $ref: '#/responses/Unauthenticated'
         403:
-          description: "Unauthorised to publish image or it is in wrong state to be published"
+          description: "Unauthorised to view images metadata"
         404:
           $ref: '#/responses/NotFound'
         500:
           $ref: '#/responses/InternalError'
 
   /images/{image_id}/downloads/{variant}:
+    get:
+      tags:
+        - "image"
+      produces:
+        - "application/json"
+      security:
+        - FlorenceAPIKey: []
+      parameters:
+        - $ref: '#/parameters/image_id'
+        - $ref: '#/parameters/variant'
+      responses:
+        200:
+          description: "Successfully updated download variant."
+          schema:
+            $ref: '#/definitions/ImageDownload'
+        401:
+          $ref: '#/responses/Unauthenticated'
+        403:
+          description: "Unauthorised to view images metadata"
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/InternalError'
     put:
       tags:
-      - "image"
+        - "image"
       summary: "Update an image download variant"
       description: "Update the image download fields for the provided variant of the provided image."
-      parameters:
-      - $ref: '#/parameters/image_id'
-      - $ref: '#/parameters/variant'
-      - $ref: '#/parameters/update_download'
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
-      - ServiceAPIKey: []
+        - FlorenceAPIKey: []
+        - ServiceAPIKey: []
+      parameters:
+        - $ref: '#/parameters/image_id'
+        - $ref: '#/parameters/variant'
+        - $ref: '#/parameters/image_download'
       responses:
         200:
           description: "A json with the download varint afeter veing updated"
@@ -219,54 +236,27 @@ paths:
         500:
           $ref: '#/responses/InternalError'
 
-
-  /images/{image_id}/downloads/{variant}/import:
+  /images/{image_id}/publish:
     post:
       tags:
-      - "image"
-      summary: "Import an image download variant"
-      description: "Update an image download variant state to 'importing' state, just before the variant is generated."
+        - "image"
+      summary: "Publish an image"
+      description: "Requests an image publishing via the static file publisher, which puts the S3 objects for this image to the static bucket. This call sets the image state to 'publishing'."
       parameters:
-      - $ref: '#/parameters/image_id'
-      - $ref: '#/parameters/variant'
+        - $ref: '#/parameters/image_id'
       produces:
-      - "application/json"
+        - "application/json"
       security:
-      - FlorenceAPIKey: []
+        - FlorenceAPIKey: []
       responses:
         200:
-          description: "The image download variant was successfully updated to 'importing' state."
+          description: "The image publishing was successfully requested to Static file publisher."
         400:
-          description: "Invalid request"
+          description: "Invalid request, image id was incorrect"
         401:
           $ref: '#/responses/Unauthenticated'
         403:
-          description: "Unauthorised to import image download variant or the image or download variant is in wrong state to be imported"
-        404:
-          $ref: '#/responses/NotFound'
-        500:
-          $ref: '#/responses/InternalError'
-  
-  /images/{image_id}/downloads/{variant}/complete:
-    post:
-      tags:
-      - "image"
-      summary: "Complete an image download variant"
-      description: "Update an image download variant to 'completed' state. If all download variants have been completed, the high level image state will also be updated to 'completed'. If any download variant failed to publish, the high level image state will be updated to 'failed_publish'."
-      parameters:
-      - $ref: '#/parameters/image_id'
-      - $ref: '#/parameters/variant'
-      produces:
-      - "application/json"
-      security:
-      - FlorenceAPIKey: []
-      responses:
-        200:
-          description: "The image download variant was successfully updated to 'completed' state."
-        401:
-          $ref: '#/responses/Unauthenticated'
-        403:
-          description: "Unauthorised to complete image download variant or the image or download variant is in wrong state to be completed"
+          description: "Unauthorised to publish image or it is in wrong state to be published"
         404:
           $ref: '#/responses/NotFound'
         500:
@@ -276,10 +266,10 @@ responses:
 
   InternalError:
     description: "Failed to process the request due to an internal error"
-    
+
   NotFound:
     description: "Requested item cannot be found"
-    
+
   InvalidRequestError:
     description: "Failed to process the request due to invalid request"
 
@@ -319,6 +309,12 @@ definitions:
     required:
       - "collection_id"
     properties:
+      state:
+        type: string
+        enum:
+          - created
+        description: "The state of the image"
+        example: "created"
       collection_id:
         type: string
         description: "Collection unique identifier corresponding to this image"
@@ -336,7 +332,7 @@ definitions:
             type: string
             description: "Title of the license"
             example: "Open Government Licence v3.0"
-          href: 
+          href:
             type: string
             description: "Link to the license content"
             example: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
@@ -393,39 +389,69 @@ definitions:
             type: string
             description: "Title of the license"
             example: "Open Government Licence v3.0"
-          href: 
+          href:
             type: string
             description: "Link to the license content"
             example: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+      links:
+        $ref: '#/definitions/ImageLinks'
       upload:
         $ref: '#/definitions/ImageUpload'
       type:
         type: string
         description: "Type of image, which might define a set of possible formats and variants or resolutions."
         example: "chart"
+
+  ImageLinks:
+    type: object
+    properties:
+      self:
+        type: string
       downloads:
-        type: object
-        description: "All available variants for this image. Note that this spec is not a comprehensive list of cases; it only shows a few examples of possible image variant keys."
-        properties:
-          original:
-            $ref: '#/definitions/ImageDownload'
-          png:
-            $ref: '#/definitions/ImageDownload'
-          svg:
-            $ref: '#/definitions/ImageDownload'
-          png_w500:
-            $ref: '#/definitions/ImageDownload'
-          svg_w500:
-            $ref: '#/definitions/ImageDownload'
-          png_bw:
-            $ref: '#/definitions/ImageDownload'
-          png_w500_bw:
-            $ref: '#/definitions/ImageDownload'
+        type: string
+        example: "https://localhost:100000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35/downloads"
+
+  ImageDownloads:
+    description: "A list of image download variants"
+    type: object
+    properties:
+      count:
+        description: "The number of image downloads returned"
+        readOnly: true
+        type: integer
+        example: 1
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/ImageDownload'
+      limit:
+        description: "The number of image downloads requested"
+        type: integer
+      offset:
+        description: "The first row of image downloads to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the limit parameter"
+        type: integer
+      total_count:
+        description: "The total number of image downloads"
+        readOnly: true
+        type: integer
+        example: 1
 
   ImageDownload:
     type: object
     description: "Download information for a particular image variant and resolution"
     properties:
+      id:
+        type: string
+        description: "the variant"
+        example: "original"
+      links:
+        type: object
+        properties:
+          self:
+            type: string
+          image:
+            type: string
+            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
       size:
         type: integer
         description: "File size in number of bytes"
@@ -485,19 +511,23 @@ definitions:
         type: string
         description: "Timestamp representation for the publishing process completion, formatted according to RFC3339"
         example: "2020-04-26T10:01:28Z"
-        
-  ImageDownloadUpdate:
+
+  NewImageDownload:
     type: object
-    description: "Subset of ImageDownload variant that can be updated by a caller"
+    description: "New download information for a particular image variant and resolution"
     properties:
-      size:
-        type: integer
-        description: "File size in number of bytes"
-        example: 1024000
-      palette:
+      id:
         type: string
-        description: "Image palette"
-        example: "bw"
+        description: "the variant"
+        example: "original"
+      links:
+        type: object
+        properties:
+          self:
+            type: string
+          image:
+            type: string
+            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
       type:
         type: string
         description: "Type of download corresponding to this variant"
@@ -510,10 +540,17 @@ definitions:
         type: integer
         description: "Image height, in number of pixels"
         example: 1080
-      private:
+      state:
         type: string
-        description: "S3 Private bucket name"
-        example: "my-private-bucket"
+        description: "The state of this download variant. The high level image will change its state to imported only when all variants are in imported state."
+        enum:
+          - pending
+          - importing
+          - imported
+          - published
+          - completed
+          - failed
+        example: "published"
 
 securityDefinitions:
 
@@ -537,20 +574,20 @@ parameters:
     required: true
     in: path
     type: string
-  
+
   variant:
     name: variant
     description: "A unique image download variant identifier"
     required: true
     in: path
     type: string
-    
+
   collection_id:
     name: collection_id
     description: "A unique id for a collection to filter on"
     in: query
     type: string
-    
+
   image:
     name: image
     description: "A valid image model, which already exists"
@@ -558,6 +595,22 @@ parameters:
     required: true
     schema:
       $ref: '#/definitions/Image'
+
+  image_download:
+    name: image_download
+    description: "A valid image download model, which already exists"
+    in: body
+    required: true
+    schema:
+      $ref: '#/definitions/ImageDownload'
+
+  new_image_download:
+    name: new_image_download
+    description: "A valid new image download"
+    in: body
+    required: true
+    schema:
+      $ref: '#/definitions/NewImageDownload'
 
   new_image:
     name: new_image
@@ -567,19 +620,4 @@ parameters:
     schema:
       $ref: '#/definitions/NewImage'
 
-  upload_image:
-    name: upload_image
-    description: "A valid upload model containing the path of the uploaded image."
-    in: body
-    required: true
-    schema:
-      $ref: '#/definitions/ImageUpload'
-
-  update_download:
-    name: update_download
-    description: "A subset of the download data model, containing only the fields that can be updated by an API caller."
-    in: body
-    required: true
-    schema:
-      $ref: '#/definitions/ImageDownloadUpdate'
   

--- a/url/builder.go
+++ b/url/builder.go
@@ -1,0 +1,27 @@
+package url
+
+import "fmt"
+
+// Builder encapsulates the building of urls in a central place, with knowledge of the url structures and base host names.
+type Builder struct {
+	apiURL string
+}
+
+// NewBuilder returns a new instance of url.Builder
+func NewBuilder(apiURL string) *Builder {
+	return &Builder{
+		apiURL: apiURL,
+	}
+}
+
+// BuildImageURL returns the website URL for a specific image
+func (builder Builder) BuildImageURL(imageID string) string {
+	return fmt.Sprintf("%s/images/%s",
+		builder.apiURL, imageID)
+}
+
+// BuildImageDownloadURL returns the website URL for a specific image dowload variant
+func (builder Builder) BuildImageDownloadURL(imageID, variant string) string {
+	return fmt.Sprintf("%s/images/%s/downloads/%s",
+		builder.apiURL, imageID, variant)
+}

--- a/url/builder_test.go
+++ b/url/builder_test.go
@@ -1,0 +1,46 @@
+package url_test
+
+import (
+	"fmt"
+	"github.com/ONSdigital/dp-image-api/url"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+const (
+	websiteURL      = "localhost:20000"
+	imageID         = "123"
+	downloadVariant = "640bw"
+)
+
+func TestBuilder_BuildWebsiteDatasetVersionURL(t *testing.T) {
+
+	Convey("Given a URL builder", t, func() {
+
+		urlBuilder := url.NewBuilder(websiteURL)
+
+		Convey("When BuildImageURL is called", func() {
+
+			url := urlBuilder.BuildImageURL(imageID)
+
+			expectedURL := fmt.Sprintf("%s/images/%s",
+				websiteURL, imageID)
+
+			Convey("Then the expected URL is returned", func() {
+				So(url, ShouldEqual, expectedURL)
+			})
+		})
+
+		Convey("When BuildImageDownloadURL is called", func() {
+
+			url := urlBuilder.BuildImageDownloadURL(imageID, downloadVariant)
+
+			expectedURL := fmt.Sprintf("%s/images/%s/downloads/%s",
+				websiteURL, imageID, downloadVariant)
+
+			Convey("Then the expected URL is returned", func() {
+				So(url, ShouldEqual, expectedURL)
+			})
+		})
+	})
+}


### PR DESCRIPTION
In this release:

* Remove upload image endpoint (`POST /images/{id}/upload`) as this functionality is available more RESTfully through the update image endpoint (`PUT /images/{id}`)
* Remove import image variant endpoint (`POST /images/{id}/downloads/{variant}/import`) as this functionality is available more RESTfully through the update image variant endpoint (`PUT /images/{id}/downloads/{variant}`)
* Remove complete image variant endpoint (`POST /images/{id}/downloads/{variant}/complete `) as this functionality is available more RESTfully through the update image variant endpoint (`PUT /images/{id}/downloads/{variant}`)
* Add list image download variants endpoint (`GET /images/{id}/downloads`)
* Add get image download variant details endpoint (`GET /images/{id}/downloads/{variant}`)
* Add create image download variant endpoint (`POST /images/{id}/downloads`)