### PR TITLE
Tidy up endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -124,7 +124,8 @@ func handleError(ctx context.Context, w http.ResponseWriter, err error, data log
 			apierrors.ErrImageInvalidState,
 			apierrors.ErrImageDownloadTypeMismatch,
 			apierrors.ErrImageDownloadInvalidState,
-			apierrors.ErrImageIDMismatch:
+			apierrors.ErrImageIDMismatch,
+			apierrors.ErrVariantIDMismatch:
 			status = http.StatusBadRequest
 		case apierrors.ErrImageAlreadyPublished,
 			apierrors.ErrImageAlreadyCompleted,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -123,7 +123,7 @@ func TestClose(t *testing.T) {
 func GetAPIWithMocks(cfg *config.Config, mongoDbMock *mock.MongoServerMock, authHandlerMock *mock.AuthHandlerMock, uploadedKafkaProducerMock, publishedKafkaProducerMock kafka.IProducer) *api.API {
 	mu.Lock()
 	defer mu.Unlock()
-	urlBuilder := url.NewBuilder("")
+	urlBuilder := url.NewBuilder("http://example.com")
 	return api.Setup(testContext, cfg, mux.NewRouter(), authHandlerMock, mongoDbMock, uploadedKafkaProducerMock, publishedKafkaProducerMock, urlBuilder)
 }
 

--- a/api/image.go
+++ b/api/image.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"context"
+	"net/http"
+	"net/url"
+
 	"github.com/ONSdigital/dp-image-api/apierrors"
 	"github.com/ONSdigital/dp-image-api/event"
 	"github.com/ONSdigital/dp-image-api/models"
@@ -10,8 +13,6 @@ import (
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
 	uuid "github.com/satori/go.uuid"
-	"net/http"
-	"net/url"
 )
 
 // NewID returns a new UUID

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -1545,6 +1545,17 @@ func TestUpdateDownloadHandler(t *testing.T) {
 				So(len(mongoDBMock.AcquireImageLockCalls()), ShouldEqual, 1)
 				So(len(mongoDBMock.UnlockImageCalls()), ShouldEqual, 1)
 			})
+
+			Convey("Calling update download with a download that has a different id results in 400 response", func() {
+				r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:24700/images/%s/downloads/%s", testImageID2, testVariantOriginal), bytes.NewBufferString(
+					fmt.Sprintf(updateImageDownloadImportedPayloadFmt, testVariantAlternative, testDownloadType, models.StateDownloadImported.String())))
+				r = r.WithContext(context.WithValue(r.Context(), dphttp.FlorenceIdentityKey, testUserAuthToken))
+				r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID1))
+				w := httptest.NewRecorder()
+				imageApi.Router.ServeHTTP(w, r)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
+
 		})
 
 		Convey("And an image in 'uploaded' state in MongoDB, without any download variants", func() {

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -19,6 +19,8 @@ var (
 	ErrImageAlreadyCompleted            = errors.New("image is already completed")
 	ErrImageInvalidState                = errors.New("image state is not a valid state name")
 	ErrImageStateTransitionNotAllowed   = errors.New("image state transition not allowed")
+	ErrImageUploadEmpty                 = errors.New("image upload section is not populated")
+	ErrImageUploadPathEmpty             = errors.New("image upload path is not populated")
 	ErrImageNotImporting                = errors.New("image is not in importing state")
 	ErrImageNotPublished                = errors.New("image is not in published state")
 	ErrVariantStateTransitionNotAllowed = errors.New("image download variant state transition not allowed")

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrImageUploadPathEmpty             = errors.New("image upload path is not populated")
 	ErrImageNotImporting                = errors.New("image is not in importing state")
 	ErrImageNotPublished                = errors.New("image is not in published state")
+	ErrVariantIDMismatch                = errors.New("variant id provided in body does not match 'variant' path parameter")
 	ErrVariantStateTransitionNotAllowed = errors.New("image download variant state transition not allowed")
 	ErrImageDownloadTypeMismatch        = errors.New("image download variant type does not match existing type")
 	ErrImageDownloadInvalidState        = errors.New("image download state is not a valid state name")

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 
+    tag: 1.13.15
 
 inputs:
   - name: dp-image-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 
+    tag: 1.13.15
 
 inputs:
   - name: dp-image-api

--- a/models/image.go
+++ b/models/image.go
@@ -103,6 +103,24 @@ func (i *Image) Validate() error {
 		}
 	}
 
+	// Check uploaded images have a valid upload path
+	if i.State == StateUploaded.String() {
+		err := validateUpload(i.Upload)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateUpload(upload *Upload) error {
+	if upload == nil {
+		return apierrors.ErrImageUploadEmpty
+	}
+	if len(upload.Path) < 1 {
+		return apierrors.ErrImageUploadPathEmpty
+	}
 	return nil
 }
 

--- a/models/image.go
+++ b/models/image.go
@@ -32,6 +32,7 @@ type Image struct {
 	State        string              `bson:"state,omitempty"         json:"state,omitempty"`
 	Filename     string              `bson:"filename,omitempty"      json:"filename,omitempty"`
 	License      *License            `bson:"license,omitempty"       json:"license,omitempty"`
+	Links        *ImageLinks         `bson:"links,omitempty"         json:"links,omitempty"`
 	Upload       *Upload             `bson:"upload,omitempty"        json:"upload,omitempty"`
 	Type         string              `bson:"type,omitempty"          json:"type,omitempty"`
 	Downloads    map[string]Download `bson:"downloads,omitempty"     json:"-"`
@@ -41,6 +42,11 @@ type Image struct {
 type License struct {
 	Title string `bson:"title,omitempty"            json:"title,omitempty"`
 	Href  string `bson:"href,omitempty"             json:"href,omitempty"`
+}
+
+type ImageLinks struct {
+	Self      string `bson:"self,omitempty"         json:"self,omitempty"`
+	Downloads string `bson:"downloads,omitempty"    json:"downloads,omitempty"`
 }
 
 // Upload represents an upload model

--- a/models/image.go
+++ b/models/image.go
@@ -100,6 +100,25 @@ func (i *Image) Validate() error {
 	return nil
 }
 
+// ValidateTransitionFrom checks that this image state can be validly transitioned from the existing state
+func (i *Image) ValidateTransitionFrom(existing *Image) error {
+
+	// check that state transition is allowed, only if state is provided
+	if i.State != "" {
+		if !existing.StateTransitionAllowed(i.State) {
+			return apierrors.ErrImageStateTransitionNotAllowed
+			return nil
+		}
+	}
+
+	// if the image is already completed, it cannot be updated
+	if existing.State == StateCompleted.String() {
+		return apierrors.ErrImageAlreadyCompleted
+	}
+
+	return nil
+}
+
 // StateTransitionAllowed checks if the image can transition from its current state to the provided target state
 func (i *Image) StateTransitionAllowed(target string) bool {
 	currentState, err := ParseState(i.State)

--- a/models/image_test.go
+++ b/models/image_test.go
@@ -102,6 +102,23 @@ func TestImageValidation(t *testing.T) {
 		So(err, ShouldResemble, apierrors.ErrImageInvalidState)
 	})
 
+	Convey("Given an image with a state of uploaded has no upload section it fails to validate with the expected error", t, func() {
+		image := models.Image{
+			State: "uploaded",
+		}
+		err := image.Validate()
+		So(err, ShouldResemble, apierrors.ErrImageUploadEmpty)
+	})
+
+	Convey("Given an image with a state of uploaded has no path in its upload section it fails to validate with the expected error", t, func() {
+		image := models.Image{
+			State:  "uploaded",
+			Upload: &models.Upload{},
+		}
+		err := image.Validate()
+		So(err, ShouldResemble, apierrors.ErrImageUploadPathEmpty)
+	})
+
 	Convey("Given a fully populated valid image with a valid download variant, it is successfully validated", t, func() {
 		image := models.Image{
 			ID:           "123",

--- a/models/image_test.go
+++ b/models/image_test.go
@@ -163,7 +163,7 @@ func TestImageValidateTransitionFrom(t *testing.T) {
 				State: models.StateDeleted.String(),
 			}
 			err := image.ValidateTransitionFrom(existing)
-			So(err, ShouldResemble, apierrors.ErrImageStateTransitionNotAllowed)
+			So(err, ShouldResemble, apierrors.ErrImageAlreadyCompleted)
 		})
 	})
 }

--- a/models/image_test.go
+++ b/models/image_test.go
@@ -122,6 +122,52 @@ func TestImageValidation(t *testing.T) {
 	})
 }
 
+func TestImageValidateTransitionFrom(t *testing.T) {
+	Convey("Given an existing image in an uploaded state", t, func() {
+		existing := &models.Image{
+			State: models.StateUploaded.String(),
+		}
+
+		Convey("When we try to transition to an Importing state", func() {
+			image := &models.Image{
+				State: models.StateImporting.String(),
+			}
+			err := image.ValidateTransitionFrom(existing)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("When we try to transition to a Created state", func() {
+			image := &models.Image{
+				State: models.StateCreated.String(),
+			}
+			err := image.ValidateTransitionFrom(existing)
+			So(err, ShouldResemble, apierrors.ErrImageStateTransitionNotAllowed)
+		})
+	})
+
+	Convey("Given an existing image in a Completed state", t, func() {
+		existing := &models.Image{
+			State: models.StateCompleted.String(),
+		}
+
+		Convey("When we try to transition to an Importing state", func() {
+			image := &models.Image{
+				State: models.StateImporting.String(),
+			}
+			err := image.ValidateTransitionFrom(existing)
+			So(err, ShouldResemble, apierrors.ErrImageStateTransitionNotAllowed)
+		})
+
+		Convey("When we try to transition to a Deleted state", func() {
+			image := &models.Image{
+				State: models.StateDeleted.String(),
+			}
+			err := image.ValidateTransitionFrom(existing)
+			So(err, ShouldResemble, apierrors.ErrImageStateTransitionNotAllowed)
+		})
+	})
+}
+
 func TestImageStateTransitionAllowed(t *testing.T) {
 	Convey("Given an image in created state", t, func() {
 		image := models.Image{

--- a/service/service.go
+++ b/service/service.go
@@ -219,7 +219,7 @@ func registerCheckers(ctx context.Context,
 
 		if err = hc.AddCheck("Zebedee", zebedeeClient.Checker); err != nil {
 			hasErrors = true
-			log.Event(ctx, "error adding check for zebedeee", log.ERROR, log.Error(err))
+			log.Event(ctx, "error adding check for zebedee", log.ERROR, log.Error(err))
 		}
 	}
 

--- a/url/builder.go
+++ b/url/builder.go
@@ -20,6 +20,12 @@ func (builder Builder) BuildImageURL(imageID string) string {
 		builder.apiURL, imageID)
 }
 
+// BuildImageBuildImageDownloadsURL returns the website URL for a collection of downloads for this image
+func (builder Builder) BuildImageDownloadsURL(imageID string) string {
+	return fmt.Sprintf("%s/images/%s/downloads",
+		builder.apiURL, imageID)
+}
+
 // BuildImageDownloadURL returns the website URL for a specific image dowload variant
 func (builder Builder) BuildImageDownloadURL(imageID, variant string) string {
 	return fmt.Sprintf("%s/images/%s/downloads/%s",

--- a/url/builder_test.go
+++ b/url/builder_test.go
@@ -31,6 +31,18 @@ func TestBuilder_BuildWebsiteDatasetVersionURL(t *testing.T) {
 			})
 		})
 
+		Convey("When BuildImageDownloadsURL is called", func() {
+
+			url := urlBuilder.BuildImageDownloadsURL(imageID)
+
+			expectedURL := fmt.Sprintf("%s/images/%s/downloads",
+				websiteURL, imageID)
+
+			Convey("Then the expected URL is returned", func() {
+				So(url, ShouldEqual, expectedURL)
+			})
+		})
+
 		Convey("When BuildImageDownloadURL is called", func() {
 
 			url := urlBuilder.BuildImageDownloadURL(imageID, downloadVariant)


### PR DESCRIPTION
### What

Tidy up endpoints task.

- Update `PUT /images/{id}` to include upload
- Update `PUT /images/{id}/downloads/{variant}` to cover import and complete of downloads
- Add Links section to `POST /images`

### How to review

- Ensure that the `PUT /images/{id}` endpoint has replaced the former `POST /images/{id}/upload` endpoint and that appropriate tests are in place. 
- Ensure that the `PUT /images/{id}/downloads/{variant}` endpoint…
  - has replaced the former `POST /images/{id}/downloads/{variant}/import` endpoint and that appropriate tests are in place. 
  - has replaced the former `POST /images/{id}/downloads/{variant}/complete` endpoint and that appropriate tests are in place. 
- Ensure that the model matches the swagger spec.
- Check that the links section is populated on image creation (POST) and copied from the existing image in MongoDB on update4s (PUT).

### Who can review

Anyone but me