### PR TITLE
Validate state on image creation and clean up Swagger

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -130,6 +130,7 @@ func handleError(ctx context.Context, w http.ResponseWriter, err error, data log
 		case apierrors.ErrImageAlreadyPublished,
 			apierrors.ErrImageAlreadyCompleted,
 			apierrors.ErrImageStateTransitionNotAllowed,
+			apierrors.ErrImageBadInitialState,
 			apierrors.ErrImageNotImporting,
 			apierrors.ErrImageNotPublished,
 			apierrors.ErrVariantAlreadyExists,

--- a/api/image.go
+++ b/api/image.go
@@ -92,7 +92,7 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 	newImage := models.Image{
 		ID:           id,
 		CollectionID: newImageRequest.CollectionID,
-		State:        models.StateCreated.String(),
+		State:        newImageRequest.State,
 		Filename:     newImageRequest.Filename,
 		License:      newImageRequest.License,
 		Links:        api.createLinksForImage(id),
@@ -102,6 +102,12 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 	// generic image validation
 	if err := newImage.Validate(); err != nil {
 		handleError(ctx, w, err, logdata)
+		return
+	}
+
+	// Check provided image state supplied is correct
+	if newImage.State != models.StateCreated.String() {
+		handleError(ctx, w, apierrors.ErrImageBadInitialState, logdata)
 		return
 	}
 

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrImageAlreadyPublished            = errors.New("image is already published")
 	ErrImageAlreadyCompleted            = errors.New("image is already completed")
 	ErrImageInvalidState                = errors.New("image state is not a valid state name")
+	ErrImageBadInitialState             = errors.New("image state is not a valid initial state")
 	ErrImageStateTransitionNotAllowed   = errors.New("image state transition not allowed")
 	ErrImageUploadEmpty                 = errors.New("image upload section is not populated")
 	ErrImageUploadPathEmpty             = errors.New("image upload path is not populated")

--- a/models/image.go
+++ b/models/image.go
@@ -59,15 +59,15 @@ type Downloads struct {
 // Download represents a download variant model
 type Download struct {
 	ID               string         `bson:"id,omitempty"                 json:"id,omitempty"`
-	Size             *int           `bson:"size,omitempty"               json:"size,omitempty"`
+	Height           *int           `bson:"height,omitempty"             json:"height,omitempty"`
+	Href             string         `json:"href,omitempty"`
 	Palette          string         `bson:"palette,omitempty"            json:"palette,omitempty"`
+	Private          string         `bson:"private,omitempty"            json:"private,omitempty"`
+	Public           bool           `json:"public,omitempty"`
+	Size             *int           `bson:"size,omitempty"               json:"size,omitempty"`
 	Type             string         `bson:"type,omitempty"               json:"type,omitempty"`
 	Width            *int           `bson:"width,omitempty"              json:"width,omitempty"`
-	Height           *int           `bson:"height,omitempty"             json:"height,omitempty"`
-	Public           bool           `json:"public,omitempty"`
-	Href             string         `json:"href,omitempty"`
 	Links            *DownloadLinks `bson:"links,omitempty"              json:"links,omitempty"`
-	Private          string         `bson:"private,omitempty"            json:"private,omitempty"`
 	State            string         `bson:"state,omitempty"              json:"state,omitempty"`
 	Error            string         `bson:"error,omitempty"              json:"error,omitempty"`
 	ImportStarted    *time.Time     `bson:"import_started,omitempty"     json:"import_started,omitempty"`
@@ -90,10 +90,8 @@ func (i *Image) Validate() error {
 		}
 	}
 
-	if i.State != "" {
-		if _, err := ParseState(i.State); err != nil {
-			return apierrors.ErrImageInvalidState
-		}
+	if _, err := ParseState(i.State); err != nil {
+		return apierrors.ErrImageInvalidState
 	}
 
 	// Check uploaded images have a valid upload path

--- a/models/image_test.go
+++ b/models/image_test.go
@@ -99,9 +99,18 @@ func TestImageAnyDownloadsOfState(t *testing.T) {
 func TestImageValidation(t *testing.T) {
 
 	Convey("Given an empty image, it is successfully validated", t, func() {
-		image := models.Image{}
+		image := models.Image{
+			State: models.StateCreated.String(),
+		}
 		err := image.Validate()
 		So(err, ShouldBeNil)
+	})
+
+	Convey("Given an image with no state supplied, it fails to validate  with the expected error", t, func() {
+		image := models.Image{}
+		err := image.Validate()
+		So(err, ShouldResemble, apierrors.ErrImageInvalidState)
+
 	})
 
 	Convey("Given an image with a filename that is longer than the maximum allowed, it fails to validate with the expected error", t, func() {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -453,14 +453,26 @@ definitions:
         type: string
         description: "the variant"
         example: "original"
-      links:
-        type: object
-        properties:
-          self:
-            type: string
-          image:
-            type: string
-            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
+      height:
+        type: integer
+        description: "Image height, in number of pixels"
+        example: 1080
+      href:
+        type: string
+        description: "Full URL pointing to the image in download service"
+        example: "http://download.ons.gov.uk/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35/image-name.png"
+      palette:
+        type: string
+        description: "Colour palette of the variant"
+        example: "bw"
+      private:
+        type: string
+        description: "S3 Private bucket name"
+        example: "my-private-bucket"
+      public:
+        type: boolean
+        description: "Determines if this image variant is public (i.e. it can be accessed under static.ons.gov.uk)"
+        example: true
       size:
         type: integer
         description: "File size in number of bytes"
@@ -473,22 +485,14 @@ definitions:
         type: integer
         description: "Image width, in number of pixels"
         example: 1920
-      height:
-        type: integer
-        description: "Image height, in number of pixels"
-        example: 1080
-      public:
-        type: boolean
-        description: "Determines if this image variant is public (i.e. it can be accessed under static.ons.gov.uk)"
-        example: true
-      href:
-        type: string
-        description: "Full URL pointing to the image in download service"
-        example: "http://download.ons.gov.uk/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35/image-name.png"
-      private:
-        type: string
-        description: "S3 Private bucket name"
-        example: "my-private-bucket"
+      links:
+        type: object
+        properties:
+          self:
+            type: string
+          image:
+            type: string
+            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
       state:
         type: string
         description: "The state of this download variant. The high level image will change its state to imported only when all variants are in imported state."
@@ -530,14 +534,10 @@ definitions:
         type: string
         description: "the variant"
         example: "original"
-      links:
-        type: object
-        properties:
-          self:
-            type: string
-          image:
-            type: string
-            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
+      height:
+        type: integer
+        description: "Image height, in number of pixels"
+        example: 1080
       type:
         type: string
         description: "Type of download corresponding to this variant"
@@ -546,10 +546,14 @@ definitions:
         type: integer
         description: "Image width, in number of pixels"
         example: 1920
-      height:
-        type: integer
-        description: "Image height, in number of pixels"
-        example: 1080
+      links:
+        type: object
+        properties:
+          self:
+            type: string
+          image:
+            type: string
+            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
       state:
         type: string
         description: "The state of this download variant. On creation the only allowed states are pending or importing."

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -316,7 +316,9 @@ definitions:
     type: object
     description: "New Image metadata model, used to create new images. The image ID will be created by image API, and the state will be set to 'created' at creation time."
     required:
+      - "state"
       - "collection_id"
+      - "type"
     properties:
       state:
         type: string
@@ -362,6 +364,11 @@ definitions:
   Image:
     type: object
     description: "Existing Image metadata model"
+    required:
+      - "id"
+      - "state"
+      - "collection_id"
+      - "type"
     properties:
       id:
         type: string
@@ -448,6 +455,10 @@ definitions:
   ImageDownload:
     type: object
     description: "Download information for a particular image variant and resolution"
+    required:
+      - "id"
+      - "state"
+      - "import_started"
     properties:
       id:
         type: string
@@ -490,6 +501,7 @@ definitions:
         properties:
           self:
             type: string
+            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35/downloads/original"
           image:
             type: string
             example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
@@ -529,6 +541,10 @@ definitions:
   NewImageDownload:
     type: object
     description: "New download information for a particular image variant and resolution"
+    required:
+      - "id"
+      - "state"
+      - "import_started"
     properties:
       id:
         type: string
@@ -538,6 +554,10 @@ definitions:
         type: integer
         description: "Image height, in number of pixels"
         example: 1080
+      palette:
+        type: string
+        description: "Colour palette of the variant"
+        example: "bw"
       type:
         type: string
         description: "Type of download corresponding to this variant"
@@ -546,14 +566,6 @@ definitions:
         type: integer
         description: "Image width, in number of pixels"
         example: 1920
-      links:
-        type: object
-        properties:
-          self:
-            type: string
-          image:
-            type: string
-            example: "http://localhost:10000/images/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
       state:
         type: string
         description: "The state of this download variant. On creation the only allowed states are pending or importing."


### PR DESCRIPTION
### What

Update the POST /images endpoint to validate that a `state` of `created` is supplied. Also that PUT /images/{id} requires a `state` (it can't be left blank.
 
Also cleaned up the models and swagger so they are in the same order as the client and that the correct fields are marked as optional.

### How to review

- Ensure tests pass and that POST /images requires a valid `state`
- Ensure image model validation no longer allows an empty `state`
- Check that swagger is valid
  - Some extra fields have been marked as required
  - `links` have been removed from NewDownload model
  - `palette` has been added to NewDownload model
 
### Who can review

Anyone but me