### PR TITLE
Add error field to image model

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 ONS Digital
+Copyright (c) 2021 ONS Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: audit test build
 
 .PHONY: audit
 audit:
-	nancy go.sum
+	go list -m all | nancy sleuth
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### License
 
-Copyright © 2020, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2021, Office for National Statistics (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.
 

--- a/api/image.go
+++ b/api/image.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path"
 	"time"
@@ -511,6 +512,9 @@ func (api *API) UpdateDownloadHandler(w http.ResponseWriter, req *http.Request) 
 
 	// Update image state based on change to download
 	image.State = image.UpdatedState()
+	if download.State == models.StateDownloadFailed.String() {
+		image.Error = fmt.Sprintf("error in variant '%s'", variant)
+	}
 
 	// Update image in mongo DB
 	err = api.mongoDB.UpsertImage(ctx, id, image)

--- a/models/image.go
+++ b/models/image.go
@@ -23,6 +23,7 @@ type Image struct {
 	ID           string              `bson:"_id,omitempty"           json:"id,omitempty"`
 	CollectionID string              `bson:"collection_id,omitempty" json:"collection_id,omitempty"`
 	State        string              `bson:"state,omitempty"         json:"state,omitempty"`
+	Error        string              `bson:"error,omitempty"         json:"error,omitempty"`
 	Filename     string              `bson:"filename,omitempty"      json:"filename,omitempty"`
 	License      *License            `bson:"license,omitempty"       json:"license,omitempty"`
 	Links        *ImageLinks         `bson:"links,omitempty"         json:"links,omitempty"`

--- a/models/state.go
+++ b/models/state.go
@@ -47,7 +47,7 @@ func (s State) TransitionAllowed(target State) bool {
 		}
 	case StateUploaded:
 		switch target {
-		case StateImporting, StateDeleted:
+		case StateImporting, StateFailedImport, StateDeleted:
 			return true
 		default:
 			return false

--- a/models/state_test.go
+++ b/models/state_test.go
@@ -29,7 +29,7 @@ func TestStateValidation(t *testing.T) {
 		So(models.StateUploaded.TransitionAllowed(models.StatePublished), ShouldBeFalse)
 		So(models.StateUploaded.TransitionAllowed(models.StateCompleted), ShouldBeFalse)
 		So(models.StateUploaded.TransitionAllowed(models.StateDeleted), ShouldBeTrue)
-		So(models.StateUploaded.TransitionAllowed(models.StateFailedImport), ShouldBeFalse)
+		So(models.StateUploaded.TransitionAllowed(models.StateFailedImport), ShouldBeTrue)
 		So(models.StateUploaded.TransitionAllowed(models.StateFailedPublish), ShouldBeFalse)
 	})
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -169,6 +169,9 @@ func createImageUpdateQuery(ctx context.Context, id string, image *models.Image)
 	if image.State != "" {
 		updates["state"] = image.State
 	}
+	if image.Error != "" {
+		updates["error"] = image.Error
+	}
 	if image.Filename != "" {
 		updates["filename"] = image.Filename
 	}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -392,6 +392,10 @@ definitions:
           - failed_publish
         description: "The state of the image"
         example: "published"
+      error:
+        type: string
+        description: "Any error information, if there was an error with this image"
+        example: "publish process failed"
       filename:
         type: string
         description: "Image's file name. According to SEO recommendations, the name should not be longer than 5 words. And it should not include extension because multiple extensions for the same image might be available as download variants."


### PR DESCRIPTION
### What

Add an `error` field to the image model (similar to the one in the `ImageDownload` model). This means that when the image import/publish fail, a descriptive reason can be supplied as well.
Also…
- Fix dependency auditing
- Fix error when transitioning from 'uploaded` state to `failed-import`

### How to review

Ensure tests pass and audit passes. Notice that the swagger matches the new Image model.

### Who can review

Anyone but me