### PR TITLE
Use status 204 NoContent on image publish

### DIFF
--- a/api/image.go
+++ b/api/image.go
@@ -597,6 +597,9 @@ func (api *API) PublishImageHandler(w http.ResponseWriter, req *http.Request) {
 		handleError(ctx, w, err, logdata)
 		return
 	}
+
+	// Publish handler does not return any content on success
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // generateImagePublishEvents creates a kafka 'image-published' event for each download variant for the provided image.

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -1752,7 +1752,7 @@ func TestPublishImageHandler(t *testing.T) {
 				UnlockImageFunc:      func(id string) error { return nil },
 			}
 
-			Convey("Calling 'publish image' results in 200 OK response with the expected image state update to mongoDB and the message sent to kafka producer", func() {
+			Convey("Calling 'publish image' results in 204 NoContent response with the expected image state update to mongoDB and the message sent to kafka producer", func() {
 				publishedProducer := kafkatest.NewMessageProducer(true)
 				imageApi := GetAPIWithMocks(cfg, mongoDBMock, authHandlerMock, kafkaStubProducer, publishedProducer)
 				r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:24700/images/%s/publish", testImageID1), nil)
@@ -1760,7 +1760,7 @@ func TestPublishImageHandler(t *testing.T) {
 				r = r.WithContext(context.WithValue(r.Context(), handlers.CollectionID.Context(), testCollectionID1))
 				w := httptest.NewRecorder()
 				sentBytes := serveHTTPAndReadKafka(w, r, imageApi, publishedProducer, 2)
-				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Code, ShouldEqual, http.StatusNoContent)
 				So(mongoDBMock.GetImageCalls(), ShouldHaveLength, 1)
 				So(mongoDBMock.GetImageCalls()[0].ID, ShouldEqual, testImageID1)
 				So(mongoDBMock.UpdateImageCalls(), ShouldHaveLength, 1)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -258,8 +258,8 @@ paths:
         - FlorenceAPIKey: []
         - ServiceAPIKey: []
       responses:
-        200:
-          description: "The image publishing was successfully requested to Static file publisher."
+        204:
+          description: "The image was successfully published and a message queued to Static file publisher."
         400:
           description: "Invalid request, image id was incorrect"
         401:


### PR DESCRIPTION
### What

`POST /images/{id}/publish` returns no content so status should be 204 instead of 200.

### How to review

Check tests etc are successful and code looks tidy.

### Who can review

Anyone but me