### PR TITLE
Fix issue with incorrect content-type on image/download creation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -66,10 +66,11 @@ func (*API) Close(ctx context.Context) error {
 }
 
 // WriteJSONBody marshals the provided interface into json, and writes it to the response body.
-func WriteJSONBody(ctx context.Context, v interface{}, w http.ResponseWriter, data log.Data) error {
+func WriteJSONBody(v interface{}, w http.ResponseWriter, httpStatus int) error {
 
 	// Set headers
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(httpStatus)
 
 	// Marshal provided model
 	payload, err := json.Marshal(v)

--- a/api/image.go
+++ b/api/image.go
@@ -68,7 +68,7 @@ func (api *API) GetImagesHandler(w http.ResponseWriter, req *http.Request) {
 		Limit:      len(items),
 	}
 
-	if err := WriteJSONBody(ctx, images, w, logdata); err != nil {
+	if err := WriteJSONBody(images, w, http.StatusOK); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
@@ -130,8 +130,7 @@ func (api *API) CreateImageHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
-	if err := WriteJSONBody(ctx, newImage, w, logdata); err != nil {
+	if err := WriteJSONBody(newImage, w, http.StatusCreated); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
@@ -157,7 +156,7 @@ func (api *API) GetImageHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if err := WriteJSONBody(ctx, image, w, logdata); err != nil {
+	if err := WriteJSONBody(image, w, http.StatusOK); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
@@ -185,7 +184,7 @@ func (api *API) UpdateImageHandler(w http.ResponseWriter, req *http.Request) {
 
 	// apply the update
 	if updatedImage := api.doUpdateImage(w, req, id, image, logdata); updatedImage != nil {
-		if err := WriteJSONBody(ctx, updatedImage, w, logdata); err != nil {
+		if err := WriteJSONBody(updatedImage, w, http.StatusOK); err != nil {
 			handleError(ctx, w, err, logdata)
 			return
 		}
@@ -287,7 +286,7 @@ func (api *API) GetDownloadsHandler(w http.ResponseWriter, req *http.Request) {
 		Limit:      len(downloadsList),
 	}
 
-	if err := WriteJSONBody(ctx, downloads, w, logdata); err != nil {
+	if err := WriteJSONBody(downloads, w, http.StatusOK); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
@@ -372,8 +371,7 @@ func (api *API) CreateDownloadHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
-	if err := WriteJSONBody(ctx, newDownload, w, logdata); err != nil {
+	if err := WriteJSONBody(newDownload, w, http.StatusCreated); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
@@ -425,7 +423,7 @@ func (api *API) GetDownloadHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if err := WriteJSONBody(ctx, download, w, logdata); err != nil {
+	if err := WriteJSONBody(download, w, http.StatusOK); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}
@@ -523,7 +521,7 @@ func (api *API) UpdateDownloadHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	if err := WriteJSONBody(ctx, download, w, logdata); err != nil {
+	if err := WriteJSONBody(download, w, http.StatusOK); err != nil {
 		handleError(ctx, w, err, logdata)
 		return
 	}

--- a/api/image_test.go
+++ b/api/image_test.go
@@ -49,6 +49,8 @@ const (
 	testDownloadType       = "originally uploaded file"
 	testPrivateHref        = "http://download.ons.gov.uk/images/imageImageID2/original/some-image-name"
 	testFilename           = "some-image-name"
+	contentTypeKey         = "Content-Type"
+	contentTypeJSON        = "application/json; charset=utf-8"
 )
 
 var (
@@ -452,6 +454,7 @@ func doTestGetImagesHandler(cfg *config.Config) {
 
 			Convey("Then the expected images are returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImages := models.Images{}
@@ -470,6 +473,7 @@ func doTestGetImagesHandler(cfg *config.Config) {
 
 			Convey("Then an empty list of images is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImages := models.Images{}
@@ -487,6 +491,7 @@ func doTestGetImagesHandler(cfg *config.Config) {
 
 			Convey("Then the full list of images is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImages := models.Images{}
@@ -503,6 +508,7 @@ func doTestGetImagesHandler(cfg *config.Config) {
 			w := httptest.NewRecorder()
 			imageApi.Router.ServeHTTP(w, r)
 			So(w.Code, ShouldEqual, http.StatusOK)
+			So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 		})
 
 	})
@@ -562,6 +568,7 @@ func TestCreateImageHandler(t *testing.T) {
 
 			Convey("Then a newly created image with the new id and provided details is returned with status code 201", func() {
 				So(w.Code, ShouldEqual, http.StatusCreated)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImage := models.Image{}
@@ -579,6 +586,7 @@ func TestCreateImageHandler(t *testing.T) {
 			imageApi.Router.ServeHTTP(w, r)
 			Convey("Then a newly created image with the new id and provided details is returned with status code 201, ignoring any field that is not supposed to be provided at creation time", func() {
 				So(w.Code, ShouldEqual, http.StatusCreated)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImage := models.Image{}
@@ -707,6 +715,7 @@ func doTestGetImageHandler(cfg *config.Config) {
 			imageApi.Router.ServeHTTP(w, r)
 			Convey("Then the expected image is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImage := models.Image{}
@@ -723,6 +732,7 @@ func doTestGetImageHandler(cfg *config.Config) {
 			imageApi.Router.ServeHTTP(w, r)
 			Convey("Then the published image is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retImage := models.Image{}
@@ -933,6 +943,7 @@ func TestUpdateImageHandler(t *testing.T) {
 
 				sentBytes := serveHTTPAndReadKafka(w, r, imageApi, uploadedProducer, 1)
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				So(mongoDBMock.GetImageCalls(), ShouldHaveLength, 1)
 				So(mongoDBMock.GetImageCalls()[0].ID, ShouldEqual, testImageID2)
 				So(mongoDBMock.UpsertImageCalls(), ShouldHaveLength, 1)
@@ -1053,6 +1064,7 @@ func doTestGetDownloadsHandler(cfg *config.Config) {
 
 			Convey("Then a valid Downloads response with 0 items is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retDownloads := models.Downloads{}
@@ -1070,6 +1082,7 @@ func doTestGetDownloadsHandler(cfg *config.Config) {
 
 			Convey("Then a valid Downloads response with 1 item is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retDownloads := models.Downloads{}
@@ -1087,6 +1100,7 @@ func doTestGetDownloadsHandler(cfg *config.Config) {
 
 			Convey("Then a valid Downloads response with 2 items is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retDownloads := models.Downloads{}
@@ -1187,6 +1201,7 @@ func TestCreateDownloadHandler(t *testing.T) {
 
 			Convey("Then a newly created download is returned with status code 201", func() {
 				So(w.Code, ShouldEqual, http.StatusCreated)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retDownload := models.Download{}
@@ -1229,6 +1244,7 @@ func TestCreateDownloadHandler(t *testing.T) {
 
 			Convey("Then a newly created download is returned with status code 201", func() {
 				So(w.Code, ShouldEqual, http.StatusCreated)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retDownload := models.Download{}
@@ -1401,6 +1417,7 @@ func doTestGetDownloadHandler(cfg *config.Config) {
 
 			Convey("Then a valid Download response is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retDownloads := models.Download{}
@@ -1418,6 +1435,7 @@ func doTestGetDownloadHandler(cfg *config.Config) {
 
 			Convey("Then a valid Download response is returned with status code 200", func() {
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				payload, err := ioutil.ReadAll(w.Body)
 				So(err, ShouldBeNil)
 				retDownloads := models.Download{}
@@ -1533,6 +1551,7 @@ func TestUpdateDownloadHandler(t *testing.T) {
 				w := httptest.NewRecorder()
 				imageApi.Router.ServeHTTP(w, r)
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				So(mongoDBMock.GetImageCalls(), ShouldHaveLength, 1)
 				So(mongoDBMock.GetImageCalls()[0].ID, ShouldEqual, testImageID2)
 				So(mongoDBMock.UpsertImageCalls(), ShouldHaveLength, 1)
@@ -1601,6 +1620,7 @@ func TestUpdateDownloadHandler(t *testing.T) {
 				w := httptest.NewRecorder()
 				imageApi.Router.ServeHTTP(w, r)
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				So(mongoDBMock.GetImageCalls(), ShouldHaveLength, 1)
 				So(mongoDBMock.GetImageCalls()[0].ID, ShouldEqual, testImageID2)
 				So(mongoDBMock.UpsertImageCalls(), ShouldHaveLength, 1)
@@ -1636,6 +1656,7 @@ func TestUpdateDownloadHandler(t *testing.T) {
 				w := httptest.NewRecorder()
 				imageApi.Router.ServeHTTP(w, r)
 				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get(contentTypeKey), ShouldEqual, contentTypeJSON)
 				So(mongoDBMock.GetImageCalls(), ShouldHaveLength, 1)
 				So(mongoDBMock.GetImageCalls()[0].ID, ShouldEqual, testImageID2)
 				So(mongoDBMock.UpsertImageCalls(), ShouldHaveLength, 1)

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.5
+    tag: 1.15.8
 
 inputs:
   - name: dp-image-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.5
+    tag: 1.15.8
 
 inputs:
   - name: dp-image-api


### PR DESCRIPTION
### What

Non 200 responses were coming back with `text/plain` due to the header being set after it had been written.
This fix moves the w.WriteHeader(status) after the content type.
This bug was introduced when the create endpoints went from 200 OK to 201 Created.

### How to review

Ensure that the 201 (Created) responses come back as `application/json` now.
- POST /images
- POST /images/{id}/downloads

NB this is covered by new assertions in the unit tests.

### Who can review

Anyone but me.