### PR TITLE
Update variant href for web dl service on publish

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -20,22 +20,24 @@ import (
 
 //API provides a struct to wrap the api around
 type API struct {
-	Router            *mux.Router
-	mongoDB           MongoServer
-	auth              AuthHandler
-	uploadProducer    *event.AvroProducer
-	publishedProducer *event.AvroProducer
-	urlBuilder        *url.Builder
+	Router             *mux.Router
+	mongoDB            MongoServer
+	auth               AuthHandler
+	uploadProducer     *event.AvroProducer
+	publishedProducer  *event.AvroProducer
+	urlBuilder         *url.Builder
+	downloadServiceURL string
 }
 
 // Setup creates the API struct and its endpoints with corresponding handlers
 func Setup(ctx context.Context, cfg *config.Config, r *mux.Router, auth AuthHandler, mongoDB MongoServer, uploadedKafkaProducer, publishedKafkaProducer kafka.IProducer, builder *url.Builder) *API {
 
 	api := &API{
-		Router:     r,
-		auth:       auth,
-		mongoDB:    mongoDB,
-		urlBuilder: builder,
+		Router:             r,
+		auth:               auth,
+		mongoDB:            mongoDB,
+		urlBuilder:         builder,
+		downloadServiceURL: cfg.DownloadServiceURL,
 	}
 
 	if cfg.IsPublishing {

--- a/api/image.go
+++ b/api/image.go
@@ -573,8 +573,16 @@ func (api *API) PublishImageHandler(w http.ResponseWriter, req *http.Request) {
 		imageUpdate.Downloads[variant] = models.Download{
 			ID:             variant,
 			State:          models.StateDownloadPublished.String(),
+			Href:           fmt.Sprintf("%s/images/%s/%s/%s", api.downloadServiceURL, id, variant, existingImage.Filename),
 			PublishStarted: &startTime,
 		}
+	}
+
+	// Update image in mongo DB
+	_, err = api.mongoDB.UpdateImage(ctx, id, imageUpdate)
+	if err != nil {
+		handleError(ctx, w, err, logdata)
+		return
 	}
 
 	// Generate 'image published' events for all download variants
@@ -587,13 +595,6 @@ func (api *API) PublishImageHandler(w http.ResponseWriter, req *http.Request) {
 			handleError(ctx, w, err, logdata)
 			return
 		}
-	}
-
-	// Update image in mongo DB
-	_, err = api.mongoDB.UpdateImage(ctx, id, imageUpdate)
-	if err != nil {
-		handleError(ctx, w, err, logdata)
-		return
 	}
 
 	// Publish handler does not return any content on success

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	IsPublishing               bool          `envconfig:"IS_PUBLISHING"`
 	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
+	DownloadServiceURL         string        `envconfig:"DOWNLOAD_SERVICE_URL"`
 	MongoConfig                MongoConfig
 }
 
@@ -50,6 +51,7 @@ func Get() (*Config, error) {
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		ZebedeeURL:                 "http://localhost:8082",
 		IsPublishing:               true,
+		DownloadServiceURL:         "http://localhost:23600",
 		MongoConfig: MongoConfig{
 			BindAddr:   "localhost:27017",
 			Collection: "images",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,8 @@ func TestConfig(t *testing.T) {
 				So(cfg.MongoConfig.Database, ShouldEqual, "images")
 				So(cfg.IsPublishing, ShouldBeTrue)
 				So(cfg.ZebedeeURL, ShouldEqual, "http://localhost:8082")
+				So(cfg.DownloadServiceURL, ShouldEqual, "http://localhost:23600")
+
 			})
 
 			Convey("Then a second call to config should return the same config", func() {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -217,6 +217,9 @@ func createImageUpdateQuery(ctx context.Context, id string, image *models.Image)
 			if download.Private != "" {
 				updates[fmt.Sprintf("downloads.%s.private_bucket", variant)] = download.Private
 			}
+			if download.Href != "" {
+				updates[fmt.Sprintf("downloads.%s.href", variant)] = download.Href
+			}
 			if download.State != "" {
 				updates[fmt.Sprintf("downloads.%s.state", variant)] = download.State
 			}


### PR DESCRIPTION
### What

Update the href of each published variant when the parent image is published using `POST /images/{id}/publish`
This fixes the issue where a published image variant is still pointing to the internal "publishing" download service before it has been moved to the static bucket.
Also reordered the mongo and kafka steps on publish so even if kafka fails, the images get 'published' successfully as mongo is saved first.

There is a separate PR on dp-configs to update secrets with the web-side download service.

### How to review

Check the code makes sense and updates each variant when its parent image is published.
Ensure tests pass and code is audited.

### Who can review

Anyone but me