### PR TITLE
Fix/alt text not saved

### DIFF
--- a/models/image.go
+++ b/models/image.go
@@ -30,6 +30,8 @@ type Image struct {
 	Upload       *Upload             `bson:"upload,omitempty"        json:"upload,omitempty"`
 	Type         string              `bson:"type,omitempty"          json:"type,omitempty"`
 	Downloads    map[string]Download `bson:"downloads,omitempty"     json:"-"`
+	AltText      string              `bson:"alt_text,omitempty"      json:"alt_text,omitempty"`
+	ImageTitle   string              `bson:"image_title,omitempty"   json:"image_title,omitempty"`
 }
 
 // License represents a license model

--- a/models/image.go
+++ b/models/image.go
@@ -20,18 +20,18 @@ type Images struct {
 
 // Image represents an image metadata model as it is stored in mongoDB and json representation for API
 type Image struct {
-	ID           string              `bson:"_id,omitempty"           json:"id,omitempty"`
-	CollectionID string              `bson:"collection_id,omitempty" json:"collection_id,omitempty"`
-	State        string              `bson:"state,omitempty"         json:"state,omitempty"`
-	Error        string              `bson:"error,omitempty"         json:"error,omitempty"`
-	Filename     string              `bson:"filename,omitempty"      json:"filename,omitempty"`
-	License      *License            `bson:"license,omitempty"       json:"license,omitempty"`
-	Links        *ImageLinks         `bson:"links,omitempty"         json:"links,omitempty"`
-	Upload       *Upload             `bson:"upload,omitempty"        json:"upload,omitempty"`
-	Type         string              `bson:"type,omitempty"          json:"type,omitempty"`
-	Downloads    map[string]Download `bson:"downloads,omitempty"     json:"-"`
-	AltText      string              `bson:"alt_text,omitempty"      json:"alt_text,omitempty"`
-	ImageTitle   string              `bson:"image_title,omitempty"   json:"image_title,omitempty"`
+	ID           string              `bson:"_id,omitempty"            json:"id,omitempty"`
+	CollectionID string              `bson:"collection_id,omitempty"  json:"collection_id,omitempty"`
+	State        string              `bson:"state,omitempty"          json:"state,omitempty"`
+	Error        string              `bson:"error,omitempty"          json:"error,omitempty"`
+	Filename     string              `bson:"filename,omitempty"       json:"filename,omitempty"`
+	License      *License            `bson:"license,omitempty"        json:"license,omitempty"`
+	Links        *ImageLinks         `bson:"links,omitempty"          json:"links,omitempty"`
+	Upload       *Upload             `bson:"upload,omitempty"         json:"upload,omitempty"`
+	Type         string              `bson:"type,omitempty"           json:"type,omitempty"`
+	Downloads    map[string]Download `bson:"downloads,omitempty"      json:"-"`
+	ImageAltText string              `bson:"image_alt_text,omitempty" json:"image_alt_text,omitempty"`
+	ImageTitle   string              `bson:"image_title,omitempty"    json:"image_title,omitempty"`
 }
 
 // License represents a license model


### PR DESCRIPTION
### What

Users can't save image title and image alt text when uploading an image. 

### How to review

Input image title and image alt text when uploading an image on the homepage in Florence, click "Save & Preview", then click the "Back" and/or "Continue" button and find the image title and image alt text are missing. Pull this branch, go through the same steps and find the image title and image alt text are saved.

### Who can review

Anyone but me. 
