### PR TITLE
remove auth log namespace, which is deprecated

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -232,8 +232,6 @@ func registerCheckers(ctx context.Context,
 
 // generate permissions from dp-auth-api, using the provided health client, reusing its http Client
 func getAuthorisationHandlers(zc *health.Client) api.AuthHandler {
-	dpauth.LoggerNamespace("dp-image-api-auth")
-
 	log.Info(context.Background(), "getting Authorisation Handlers", log.Data{"zc_url": zc.URL})
 
 	authClient := dpauth.NewPermissionsClient(zc.Client)


### PR DESCRIPTION
### What

remove auth log namespace, which is deprecated - the global app namespace should be used instead

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone
