### PR TITLE
get images (GET /images) is returning a 404 if no images can be found.

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -81,13 +81,9 @@ func (m *Mongo) GetImages(ctx context.Context, collectionID string) ([]models.Im
 	}
 
 	var results []models.Image
-	count, err := m.connection.Collection(m.ActualCollectionName(config.ImagesCollection)).Find(ctx, colIDFilter, &results)
+	_, err := m.connection.Collection(m.ActualCollectionName(config.ImagesCollection)).Find(ctx, colIDFilter, &results)
 	if err != nil {
 		return nil, err
-	}
-
-	if count == 0 {
-		return nil, errs.ErrImageNotFound
 	}
 
 	return results, nil


### PR DESCRIPTION
### What
get images (GET /images) is returning a 404 if no images can be found.
This is invalid according to the Swagger specification  for the service and is removed by this commit

### How to review

Visual inspection and ensure test are passing

### Who can review

Anyone
