### PR TITLE
Add guard for missing image links

### DIFF
--- a/api/image.go
+++ b/api/image.go
@@ -663,6 +663,11 @@ func (api *API) unlockImage(ctx context.Context, lockID string) {
 
 // rewriteImageLinks rewrites the self and download links of a given image
 func rewriteImageLinks(ctx context.Context, builder links.Builder, image *models.Image) error {
+	if image.Links == nil || image.Links.Self == "" || image.Links.Downloads == "" {
+		log.Warn(ctx, "image link missing, skipping", log.Data{"image_id": image.ID})
+		return nil
+	}
+
 	var err error
 
 	image.Links.Self, err = builder.BuildLink(image.Links.Self)


### PR DESCRIPTION
### What

- Add guard for images without links
  - Some documents in sandbox images collection do not have links, which causes a nil pointer when attempting to rewrite the link.

### How to review

Sense check

### Who can review

!Me
