### PR TITLE
Fix dp-api-clients-go version to 2.273.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-image-api
 go 1.26.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0
 	github.com/ONSdigital/dp-authorisation v0.5.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-kafka/v3 v3.11.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0 h1:wJ+lfVqF7rDksQ+p6adHqoXvE0Q/4ZDfifxzLC16Vh8=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0 h1:iCn+HYkqYDTrzBuwDuvbUYCrIpOrRcVaRsMaATEpxJs=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
 github.com/ONSdigital/dp-authorisation v0.5.0 h1:k1ROJ+vgd1hDWyjj+ZdvSZGlZw73PN1k7CFVZhdyILA=
 github.com/ONSdigital/dp-authorisation v0.5.0/go.mod h1:Ep30ANa8vAWO7A5H/VsxoiJZkeCCXndnqa+tVoJuvUY=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=


### PR DESCRIPTION
### What

A recent issue described here: https://onswebsite.slack.com/archives/C1BK8ES15/p1776074364779459

was found to be caused by an upgrade to the Release Calendar API. Some investigation into this found that versions of dp-api-client-go that are >= v2.273.1 can cause Florence to break. Therefore this service is being restricted to version 2.273.0 of dp-api-clients-go by this PR.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.